### PR TITLE
Add LeakCanary

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,10 @@ android {
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+        leakCanary {
+            matchingFallbacks = ['debug']
+            initWith buildTypes.debug
+        }
         compileOptions {
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -124,5 +128,7 @@ dependencies {
 
     //Swipe button animation
     implementation 'com.facebook.shimmer:shimmer:0.5.0'
+
+    leakCanaryImplementation 'com.squareup.leakcanary:leakcanary-android:2.6'
 
 }


### PR DESCRIPTION
This PR adds a new build type (based on debug) which includes LeakCanary. I use a new buildtype so that LeakCanary is not bundled in other variants. Debug has to be used as base because Leakcanary isn't active in non-debug builds automatically.
To run this type from Android Studio on a device or an emulator go to `Build` > `Select build variant`

Implements #194