### PR TITLE
Migrate to View Binding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 def keystorePropertiesFile = rootProject.file("keystore.properties")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -154,4 +154,7 @@ dependencies {
     implementation "org.koin:koin-androidx-fragment:$koin_version"
 
     implementation 'hu.autsoft:krate:1.0.0'
+
+    // To use only without reflection variants of viewBinding
+    implementation 'com.kirich1409.viewbindingpropertydelegate:vbpd-noreflection:1.4.0'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,6 +78,9 @@ android {
         jvmTarget = '1.8'
     }
 
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/celzero/bravedns/adapter/ApkListAdapter.kt
+++ b/app/src/main/java/com/celzero/bravedns/adapter/ApkListAdapter.kt
@@ -128,7 +128,7 @@ class ApkListAdapter(var apkList: ArrayList<Apk>, private val context: Context) 
                     pos++
                 }
 
-                val bottomSheetFragment = BottomSheetFragment(context, apkList[adapterPosition])
+                val bottomSheetFragment = BottomSheetFragment(apkList[adapterPosition])
                 val frag = context as FragmentActivity
                 bottomSheetFragment.show(frag.supportFragmentManager, bottomSheetFragment.tag)
 

--- a/app/src/main/java/com/celzero/bravedns/adapter/SpinnerArrayAdapter.kt
+++ b/app/src/main/java/com/celzero/bravedns/adapter/SpinnerArrayAdapter.kt
@@ -21,38 +21,37 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
-import com.celzero.bravedns.R
 import com.celzero.bravedns.data.BraveMode
-import kotlinx.android.synthetic.main.spinner_custom_list.view.*
+import com.celzero.bravedns.databinding.SpinnerCustomListBinding
 import java.util.*
 
-class SpinnerArrayAdapter(context: Context,  braveModeList : ArrayList<BraveMode>) : ArrayAdapter<BraveMode>(context, 0, braveModeList) {
+class SpinnerArrayAdapter(context: Context, braveModeList: ArrayList<BraveMode>) : ArrayAdapter<BraveMode>(context, 0, braveModeList) {
 
-        override fun getView(position: Int, recycledView: View?, parent: ViewGroup): View {
-            return this.createView(position, recycledView, parent)
-        }
+    override fun getView(position: Int, recycledView: View?, parent: ViewGroup): View {
+        return this.createView(position, recycledView, parent)
+    }
 
-        override fun getDropDownView(position: Int, recycledView: View?, parent: ViewGroup): View {
-            return this.createView(position, recycledView, parent)
-        }
+    override fun getDropDownView(position: Int, recycledView: View?, parent: ViewGroup): View {
+        return this.createView(position, recycledView, parent)
+    }
 
-        private fun createView(position: Int, recycledView: View?, parent: ViewGroup): View {
+    private fun createView(position: Int, recycledView: View?, parent: ViewGroup): View {
 
-            val braveMode = getItem(position)
+        val braveMode = getItem(position)
 
-            val view = recycledView ?: LayoutInflater.from(context).inflate(R.layout.spinner_custom_list, parent,false)
-            /*if(Build.VERSION.SDK_INT < Build.VERSION_CODES.Q && position == 2){
-                view.modeImage.setImageResource(braveMode!!.icon)
-                view.modeText.text = braveMode.modeName
-                //view.alpha = 0.5F
-                //view.background = context.resources.getDrawable(R.color.colorAccent)
-            }*/
-
+        val b = SpinnerCustomListBinding.inflate(LayoutInflater.from(context), parent, false)
+        /*if(Build.VERSION.SDK_INT < Build.VERSION_CODES.Q && position == 2){
             view.modeImage.setImageResource(braveMode!!.icon)
             view.modeText.text = braveMode.modeName
-            //view.background = context.resources.getDrawable(R.color.colorGreen_900)
+            //view.alpha = 0.5F
+            //view.background = context.resources.getDrawable(R.color.colorAccent)
+        }*/
 
-            return view
-        }
+        b.modeImage.setImageResource(braveMode!!.icon)
+        b.modeText.text = braveMode.modeName
+        //view.background = context.resources.getDrawable(R.color.colorGreen_900)
+
+        return b.root
+    }
 
 }

--- a/app/src/main/java/com/celzero/bravedns/ui/AboutFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/AboutFragment.kt
@@ -20,26 +20,24 @@ import android.content.pm.PackageManager
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.databinding.FragmentAboutBinding
 import com.celzero.bravedns.service.AppUpdater
 import org.koin.android.ext.android.inject
 
 
-class AboutFragment : Fragment(), View.OnClickListener {
-    private var _binding: FragmentAboutBinding? = null
-    private val b get() = _binding!!
+class AboutFragment : Fragment(R.layout.fragment_about), View.OnClickListener {
+    private val b by viewBinding(FragmentAboutBinding::bind)
 
     private val appUpdater by inject<AppUpdater>()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentAboutBinding.inflate(inflater, container, false)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         initView()
-        return b.root
     }
 
     private fun initView() {
@@ -108,11 +106,6 @@ class AboutFragment : Fragment(), View.OnClickListener {
                 showNewFeaturesDialog()
             }
         }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     private fun showNewFeaturesDialog() {

--- a/app/src/main/java/com/celzero/bravedns/ui/AboutFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/AboutFragment.kt
@@ -25,6 +25,7 @@ import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
+import com.celzero.bravedns.databinding.DialogWhatsnewBinding
 import com.celzero.bravedns.databinding.FragmentAboutBinding
 import com.celzero.bravedns.service.AppUpdater
 import org.koin.android.ext.android.inject
@@ -109,19 +110,14 @@ class AboutFragment : Fragment(R.layout.fragment_about), View.OnClickListener {
     }
 
     private fun showNewFeaturesDialog() {
-        val inflater: LayoutInflater = LayoutInflater.from(requireContext())
-        val view: View = inflater.inflate(R.layout.dialog_whatsnew, null)
+        val binding = DialogWhatsnewBinding.inflate(LayoutInflater.from(requireContext()), null, false)
         //val builder: android.app.AlertDialog.Builder = AlertDialog.Builder(this)
-        val builder = AlertDialog.Builder(requireContext())
-        builder.setView(view).setTitle(getString(R.string.whats_dialog_title))
-
-        builder.setPositiveButton("Let\'s Go") { dialogInterface, _ ->
-            dialogInterface.dismiss()
-        }
-
-        builder.setCancelable(true)
-        builder.create().show()
-
+        AlertDialog.Builder(requireContext())
+            .setView(binding.root)
+            .setTitle(getString(R.string.whats_dialog_title))
+            .setPositiveButton("Let\'s Go") { dialogInterface, _ ->
+                dialogInterface.dismiss()
+            }.setCancelable(true).create().show()
     }
 
 }

--- a/app/src/main/java/com/celzero/bravedns/ui/AboutFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/AboutFragment.kt
@@ -22,28 +22,17 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import com.celzero.bravedns.R
+import com.celzero.bravedns.databinding.FragmentAboutBinding
 import com.celzero.bravedns.service.AppUpdater
 import org.koin.android.ext.android.inject
 
 
 class AboutFragment : Fragment(), View.OnClickListener {
-
-    private lateinit var websiteTxt : TextView
-    private lateinit var twitterTxt : TextView
-    private lateinit var githubTxt : TextView
-    private lateinit var  blogTxt : TextView
-    private lateinit var mailTxt : TextView
-    private lateinit var telegramTxt : TextView
-    private lateinit var faqTxt : TextView
-    private lateinit var mozillaImg : ImageView
-    private lateinit var appVersionText : TextView
-    private lateinit var appUpdateTxt : TextView
-    private lateinit var whatsNewTxt : TextView
+    private var _binding: FragmentAboutBinding? = null
+    private val b get() = _binding!!
 
     private val appUpdater by inject<AppUpdater>()
 
@@ -52,42 +41,31 @@ class AboutFragment : Fragment(), View.OnClickListener {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val view: View = inflater.inflate(R.layout.fragment_about, container, false)
-        initView(view)
-        return view
+        _binding = FragmentAboutBinding.inflate(inflater, container, false)
+        initView()
+        return b.root
     }
 
-    private fun initView(view: View) {
-        websiteTxt = view.findViewById(R.id.about_website)
-        twitterTxt = view.findViewById(R.id.about_twitter)
-        githubTxt = view.findViewById(R.id.about_github)
-        blogTxt = view.findViewById(R.id.about_blog)
-        mailTxt = view.findViewById(R.id.about_mail)
-        telegramTxt = view.findViewById(R.id.about_telegram)
-        faqTxt = view.findViewById(R.id.about_faq)
-        mozillaImg = view.findViewById(R.id.mozilla_img)
-        appVersionText = view.findViewById(R.id.about_app_version)
-        appUpdateTxt = view.findViewById(R.id.about_app_update)
-        whatsNewTxt = view.findViewById(R.id.about_whats_new)
+    private fun initView() {
 
         //Log.d(LOG_TAG,"Download source:"+ Utilities.verifyInstallerId(requireContext()))
 
 
-        websiteTxt.setOnClickListener(this)
-        twitterTxt.setOnClickListener(this)
-        githubTxt.setOnClickListener(this)
-        blogTxt.setOnClickListener(this)
-        mailTxt.setOnClickListener(this)
-        telegramTxt.setOnClickListener(this)
-        faqTxt.setOnClickListener(this)
-        mozillaImg.setOnClickListener(this)
-        appUpdateTxt.setOnClickListener(this)
-        whatsNewTxt.setOnClickListener(this)
+        b.aboutWebsite.setOnClickListener(this)
+        b.aboutTwitter.setOnClickListener(this)
+        b.aboutGithub.setOnClickListener(this)
+        b.aboutBlog.setOnClickListener(this)
+        b.aboutMail.setOnClickListener(this)
+        b.aboutTelegram.setOnClickListener(this)
+        b.aboutFaq.setOnClickListener(this)
+        b.mozillaImg.setOnClickListener(this)
+        b.aboutAppUpdate.setOnClickListener(this)
+        b.aboutWhatsNew.setOnClickListener(this)
 
         try {
             val pInfo = requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
             val version = pInfo.versionName
-            appVersionText.text = "v$version"
+            b.aboutAppVersion.text = "v$version"
         } catch (e: PackageManager.NameNotFoundException) {
             e.printStackTrace()
         }
@@ -96,46 +74,51 @@ class AboutFragment : Fragment(), View.OnClickListener {
 
     override fun onClick(view: View?) {
         when {
-            view == telegramTxt -> {
+            view == b.aboutTelegram -> {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse("http://www.telegram.me/rethinkdns"))
                 startActivity(intent)
             }
-            view == blogTxt -> {
+            view == b.aboutBlog -> {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://blog.rethinkdns.com/"))
                 startActivity(intent)
             }
-            view == faqTxt -> {
+            view == b.aboutFaq -> {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.bravedns.com/faq"))
                 startActivity(intent)
             }
-            view == githubTxt -> {
+            view == b.aboutGithub -> {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/celzero/rethink-app"))
                 startActivity(intent)
             }
-            view == mailTxt -> {
+            view == b.aboutMail -> {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse("mailto:" + "hello@celzero.com"))
                 intent.putExtra(Intent.EXTRA_SUBJECT, "[RethinkDNS]:")
                 startActivity(intent)
             }
-            view == twitterTxt -> {
+            view == b.aboutTwitter -> {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://twitter.com/rethinkdns"))
                 startActivity(intent)
             }
-            view == websiteTxt -> {
+            view == b.aboutWebsite -> {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.bravedns.com/"))
                 startActivity(intent)
             }
-            view == mozillaImg -> {
+            view == b.mozillaImg -> {
                 val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://builders.mozilla.community/alumni.html"))
                 startActivity(intent)
             }
-            view == appUpdateTxt ->{
+            view == b.aboutAppUpdate ->{
                 (requireContext() as HomeScreenActivity).checkForUpdate(true)
             }
-            view == whatsNewTxt ->{
+            view == b.aboutWhatsNew ->{
                 showNewFeaturesDialog()
             }
         }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     private fun showNewFeaturesDialog() {

--- a/app/src/main/java/com/celzero/bravedns/ui/AboutFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/AboutFragment.kt
@@ -17,12 +17,12 @@ package com.celzero.bravedns.ui
 
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import com.celzero.bravedns.R
 import com.celzero.bravedns.databinding.FragmentAboutBinding
@@ -36,20 +36,14 @@ class AboutFragment : Fragment(), View.OnClickListener {
 
     private val appUpdater by inject<AppUpdater>()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentAboutBinding.inflate(inflater, container, false)
         initView()
         return b.root
     }
 
     private fun initView() {
-
         //Log.d(LOG_TAG,"Download source:"+ Utilities.verifyInstallerId(requireContext()))
-
 
         b.aboutWebsite.setOnClickListener(this)
         b.aboutTwitter.setOnClickListener(this)
@@ -73,44 +67,44 @@ class AboutFragment : Fragment(), View.OnClickListener {
     }
 
     override fun onClick(view: View?) {
-        when {
-            view == b.aboutTelegram -> {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("http://www.telegram.me/rethinkdns"))
+        when (view) {
+            b.aboutTelegram -> {
+                val intent = Intent(Intent.ACTION_VIEW, "http://www.telegram.me/rethinkdns".toUri())
                 startActivity(intent)
             }
-            view == b.aboutBlog -> {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://blog.rethinkdns.com/"))
+            b.aboutBlog -> {
+                val intent = Intent(Intent.ACTION_VIEW, "https://blog.rethinkdns.com/".toUri())
                 startActivity(intent)
             }
-            view == b.aboutFaq -> {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.bravedns.com/faq"))
+            b.aboutFaq -> {
+                val intent = Intent(Intent.ACTION_VIEW, "https://www.bravedns.com/faq".toUri())
                 startActivity(intent)
             }
-            view == b.aboutGithub -> {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/celzero/rethink-app"))
+            b.aboutGithub -> {
+                val intent = Intent(Intent.ACTION_VIEW, "https://github.com/celzero/rethink-app".toUri())
                 startActivity(intent)
             }
-            view == b.aboutMail -> {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("mailto:" + "hello@celzero.com"))
+            b.aboutMail -> {
+                val intent = Intent(Intent.ACTION_VIEW, ("mailto:" + "hello@celzero.com").toUri())
                 intent.putExtra(Intent.EXTRA_SUBJECT, "[RethinkDNS]:")
                 startActivity(intent)
             }
-            view == b.aboutTwitter -> {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://twitter.com/rethinkdns"))
+            b.aboutTwitter -> {
+                val intent = Intent(Intent.ACTION_VIEW, "https://twitter.com/rethinkdns".toUri())
                 startActivity(intent)
             }
-            view == b.aboutWebsite -> {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.bravedns.com/"))
+            b.aboutWebsite -> {
+                val intent = Intent(Intent.ACTION_VIEW, "https://www.bravedns.com/".toUri())
                 startActivity(intent)
             }
-            view == b.mozillaImg -> {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://builders.mozilla.community/alumni.html"))
+            b.mozillaImg -> {
+                val intent = Intent(Intent.ACTION_VIEW, "https://builders.mozilla.community/alumni.html".toUri())
                 startActivity(intent)
             }
-            view == b.aboutAppUpdate ->{
+            b.aboutAppUpdate -> {
                 (requireContext() as HomeScreenActivity).checkForUpdate(true)
             }
-            view == b.aboutWhatsNew ->{
+            b.aboutWhatsNew -> {
                 showNewFeaturesDialog()
             }
         }
@@ -128,7 +122,7 @@ class AboutFragment : Fragment(), View.OnClickListener {
         val builder = AlertDialog.Builder(requireContext())
         builder.setView(view).setTitle(getString(R.string.whats_dialog_title))
 
-        builder.setPositiveButton("Let\'s Go") { dialogInterface, which ->
+        builder.setPositiveButton("Let\'s Go") { dialogInterface, _ ->
             dialogInterface.dismiss()
         }
 

--- a/app/src/main/java/com/celzero/bravedns/ui/AppInfoActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/AppInfoActivity.kt
@@ -15,16 +15,11 @@ limitations under the License.
 */
 package com.celzero.bravedns.ui
 
-import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import by.kirich1409.viewbindingdelegate.viewBinding
+import com.celzero.bravedns.R
 import com.celzero.bravedns.databinding.ActivityAppDetailsBinding
 
-class AppInfoActivity : AppCompatActivity() {
-    private lateinit var binding: ActivityAppDetailsBinding
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        binding = ActivityAppDetailsBinding.inflate(layoutInflater)
-        setContentView(binding.root)
-    }
+class AppInfoActivity : AppCompatActivity(R.layout.activity_app_details) {
+    private val b by viewBinding(ActivityAppDetailsBinding::bind)
 }

--- a/app/src/main/java/com/celzero/bravedns/ui/AppInfoActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/AppInfoActivity.kt
@@ -17,12 +17,14 @@ package com.celzero.bravedns.ui
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.celzero.bravedns.R
+import com.celzero.bravedns.databinding.ActivityAppDetailsBinding
 
-class AppInfoActivity  : AppCompatActivity(){
+class AppInfoActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityAppDetailsBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_app_details)
+        binding = ActivityAppDetailsBinding.inflate(layoutInflater)
+        setContentView(binding.root)
     }
 }

--- a/app/src/main/java/com/celzero/bravedns/ui/ApplicationManagerActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/ApplicationManagerActivity.kt
@@ -26,7 +26,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.core.net.toUri
 import androidx.recyclerview.widget.LinearLayoutManager
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.BuildConfig
+import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.ApplicationManagerApk
 import com.celzero.bravedns.animation.ViewAnimation
 import com.celzero.bravedns.database.AppInfoRepository
@@ -40,8 +42,8 @@ import kotlinx.coroutines.withContext
 import org.koin.android.ext.android.inject
 
 
-class ApplicationManagerActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
-    private lateinit var b: ActivityApplicationManagerBinding
+class ApplicationManagerActivity : AppCompatActivity(R.layout.activity_application_manager), SearchView.OnQueryTextListener {
+    private val b by viewBinding(ActivityApplicationManagerBinding::bind)
 
     private lateinit var itemAdapter: ItemAdapter<ApplicationManagerApk>
     private lateinit var fastAdapter: FastAdapter<ApplicationManagerApk>
@@ -53,9 +55,6 @@ class ApplicationManagerActivity : AppCompatActivity(), SearchView.OnQueryTextLi
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        b = ActivityApplicationManagerBinding.inflate(layoutInflater)
-        setContentView(b.root)
-
         initView()
         updateAppList()
     }

--- a/app/src/main/java/com/celzero/bravedns/ui/ApplicationManagerActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/ApplicationManagerActivity.kt
@@ -19,22 +19,18 @@ package com.celzero.bravedns.ui
 import android.app.Activity
 import android.app.ActivityManager
 import android.content.ActivityNotFoundException
-import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
+import androidx.core.net.toUri
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.celzero.bravedns.BuildConfig
-import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.ApplicationManagerApk
 import com.celzero.bravedns.animation.ViewAnimation
-import com.celzero.bravedns.database.AppDatabase
 import com.celzero.bravedns.database.AppInfoRepository
-import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.celzero.bravedns.databinding.ActivityApplicationManagerBinding
 import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.adapters.ItemAdapter
 import kotlinx.coroutines.Dispatchers
@@ -44,94 +40,82 @@ import kotlinx.coroutines.withContext
 import org.koin.android.ext.android.inject
 
 
-class ApplicationManagerActivity : AppCompatActivity(), SearchView.OnQueryTextListener{
+class ApplicationManagerActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
+    private lateinit var b: ActivityApplicationManagerBinding
 
-    private lateinit var recycle : RecyclerView
     private lateinit var itemAdapter: ItemAdapter<ApplicationManagerApk>
     private lateinit var fastAdapter: FastAdapter<ApplicationManagerApk>
     private val apkList = ArrayList<ApplicationManagerApk>()
-    private lateinit var fabAddIcon : FloatingActionButton
-    private lateinit var fabUninstallIcon : FloatingActionButton
-    private lateinit var fabAppInfoIcon : FloatingActionButton
 
-    private var editSearch: SearchView? = null
-
-    private var isRotate : Boolean = false
+    private var isRotate: Boolean = false
 
     private val appInfoRepository by inject<AppInfoRepository>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
-
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_application_manager)
+        b = ActivityApplicationManagerBinding.inflate(layoutInflater)
+        setContentView(b.root)
 
         initView()
         updateAppList()
-
     }
 
     private fun initView() {
-        recycle = findViewById(R.id.application_manager_recycler_view)
-        recycle.layoutManager = LinearLayoutManager(this)
+        b.applicationManagerRecyclerView.layoutManager = LinearLayoutManager(this)
 
-        itemAdapter =  ItemAdapter()
+        itemAdapter = ItemAdapter()
         fastAdapter = FastAdapter.with(itemAdapter)
-        editSearch = findViewById(R.id.am_search)
 
-        fabAddIcon = findViewById(R.id.am_fab_add_icon)
-        fabUninstallIcon = findViewById(R.id.am_fab_uninstall_icon)
-        fabAppInfoIcon = findViewById(R.id.am_fab_appinfo_icon)
+        b.amSearch.setOnQueryTextListener(this)
 
-        editSearch!!.setOnQueryTextListener(this)
+        b.applicationManagerRecyclerView.adapter = fastAdapter
 
-        recycle.adapter = fastAdapter
-
-        ViewAnimation.init(fabUninstallIcon)
-        ViewAnimation.init(fabAppInfoIcon)
+        ViewAnimation.init(b.amFabUninstallIcon)
+        ViewAnimation.init(b.amFabAppinfoIcon)
 
         ApplicationManagerApk.cleatList()
 
-        fabAddIcon.setOnClickListener {
+        b.amFabAddIcon.setOnClickListener {
             isRotate = ViewAnimation.rotateFab(it, !isRotate)
-            if(isRotate){
-                ViewAnimation.showIn(fabUninstallIcon)
-                ViewAnimation.showIn(fabAppInfoIcon)
-            }else{
-                ViewAnimation.showOut(fabUninstallIcon)
-                ViewAnimation.showOut(fabAppInfoIcon)
+            if (isRotate) {
+                ViewAnimation.showIn(b.amFabUninstallIcon)
+                ViewAnimation.showIn(b.amFabAppinfoIcon)
+            } else {
+                ViewAnimation.showOut(b.amFabUninstallIcon)
+                ViewAnimation.showOut(b.amFabAppinfoIcon)
             }
         }
 
-        fabUninstallIcon.setOnClickListener{
+        b.amFabUninstallIcon.setOnClickListener {
             val list = ApplicationManagerApk.getAddedList(this)
-            for(app in list){
+            for (app in list) {
                 uninstallPackage(app)
             }
         }
 
-        fabAppInfoIcon.setOnClickListener{
+        b.amFabAppinfoIcon.setOnClickListener {
             val list = ApplicationManagerApk.getAddedList(this)
-            if(list.size >= 1){
+            if (list.size >= 1) {
                 list[list.size - 1].packageName?.let { it1 -> appInfoForPackage(it1) }
             }
         }
     }
 
-    private fun uninstallPackage(app : ApplicationManagerApk){
-        val packageURI = Uri.parse("package:"+app.packageName)
-        val intent = Intent(Intent.ACTION_DELETE,packageURI)
-        intent.putExtra("packageName",app.packageName)
+    private fun uninstallPackage(app: ApplicationManagerApk) {
+        val packageURI = ("package:" + app.packageName).toUri()
+        val intent = Intent(Intent.ACTION_DELETE, packageURI)
+        intent.putExtra("packageName", app.packageName)
         startActivity(intent)
     }
 
-    private fun appInfoForPackage(packageName : String){
-        val activityManager : ActivityManager = getSystemService(Activity.ACTIVITY_SERVICE) as ActivityManager
+    private fun appInfoForPackage(packageName: String) {
+        val activityManager: ActivityManager = getSystemService(Activity.ACTIVITY_SERVICE) as ActivityManager
         activityManager.killBackgroundProcesses(packageName)
 
         try {
             //Open the specific App Info page:
             val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-            intent.data = Uri.parse("package:$packageName")
+            intent.data = "package:$packageName".toUri()
             startActivity(intent)
         } catch (e: ActivityNotFoundException) {
             //Open the generic Apps page:
@@ -141,12 +125,12 @@ class ApplicationManagerActivity : AppCompatActivity(), SearchView.OnQueryTextLi
     }
 
 
-    private fun updateAppList() = GlobalScope.launch ( Dispatchers.Default ){
+    private fun updateAppList() = GlobalScope.launch(Dispatchers.Default) {
         val appList = appInfoRepository.getAppInfoAsync()
-        appList.forEach{
-            val packageInfo = packageManager.getPackageInfo(it.packageInfo,0)
-            if(packageInfo.packageName != BuildConfig.APPLICATION_ID ) {
-                val userApk =  ApplicationManagerApk(packageManager.getPackageInfo(it.packageInfo, 0), it.appCategory, this@ApplicationManagerActivity)
+        appList.forEach {
+            val packageInfo = packageManager.getPackageInfo(it.packageInfo, 0)
+            if (packageInfo.packageName != BuildConfig.APPLICATION_ID) {
+                val userApk = ApplicationManagerApk(packageManager.getPackageInfo(it.packageInfo, 0), it.appCategory, this@ApplicationManagerActivity)
                 apkList.add(userApk)
             }
         }

--- a/app/src/main/java/com/celzero/bravedns/ui/BottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/BottomSheetFragment.kt
@@ -21,9 +21,9 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.Apk
+import com.celzero.bravedns.databinding.BottomSheetPermissionManagerBinding
 import com.celzero.bravedns.util.DatabaseHandler
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.koin.android.ext.android.inject
@@ -35,14 +35,10 @@ import org.koin.android.ext.android.inject
  * for the permissions.
  */
 class BottomSheetFragment(context : Context, apkItem : Apk) : BottomSheetDialogFragment() {
-
-    private var fragmentView: View? = null
+    private var _binding: BottomSheetPermissionManagerBinding? = null
+    private val b get() = _binding!!
 
     private var apkVal : Apk = apkItem
-
-    private lateinit var txtAutoRemove : TextView
-    private lateinit var txtAutoRevoke : TextView
-    private lateinit var txtDoNothing : TextView
     private val dbHandler by inject<DatabaseHandler>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -52,8 +48,8 @@ class BottomSheetFragment(context : Context, apkItem : Apk) : BottomSheetDialogF
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        fragmentView = inflater.inflate(R.layout.bottom_sheet_permission_manager, container, false)
-        return fragmentView
+        _binding = BottomSheetPermissionManagerBinding.inflate(inflater, container, false)
+        return b.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -65,39 +61,41 @@ class BottomSheetFragment(context : Context, apkItem : Apk) : BottomSheetDialogF
         return super.onCreateDialog(savedInstanceState)
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
     private fun initView(view : View) {
         print("initView")
         val rule = 0//HomeScreenActivity.dbHandler.getSpecificPackageRule(apkVal.packageName)
         //Toast.makeText(contextV,"Rule:"+rule,Toast.LENGTH_SHORT).show()
-        txtAutoRemove = view.findViewById(R.id.textView)
-        txtAutoRevoke = view.findViewById(R.id.textView2)
-        txtDoNothing = view.findViewById(R.id.textView3)
 
         if(rule == 0){
-            txtDoNothing.setCompoundDrawablesWithIntrinsicBounds(0,0,R.drawable.ok,0)
-            txtAutoRemove.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
-            txtAutoRevoke.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
+            b.txtDoNothing.setCompoundDrawablesWithIntrinsicBounds(0,0,R.drawable.ok,0)
+            b.txtAutoRemove.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
+            b.txtAutoRevoke.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
         }else if(rule == 1){
-            txtAutoRevoke.setCompoundDrawablesWithIntrinsicBounds(0,0,R.drawable.ok,0)
-            txtAutoRemove.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
-            txtDoNothing.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
+            b.txtAutoRevoke.setCompoundDrawablesWithIntrinsicBounds(0,0,R.drawable.ok,0)
+            b.txtAutoRemove.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
+            b.txtDoNothing.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
         }else if(rule == 2){
-            txtAutoRemove.setCompoundDrawablesWithIntrinsicBounds(0,0,R.drawable.ok,0)
-            txtAutoRevoke.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
-            txtDoNothing.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
+            b.txtAutoRemove.setCompoundDrawablesWithIntrinsicBounds(0,0,R.drawable.ok,0)
+            b.txtAutoRevoke.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
+            b.txtDoNothing.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
         }
 
-        txtAutoRemove.setOnClickListener{
+        b.txtAutoRemove.setOnClickListener{
             dbHandler.updatePackage(apkVal.packageName , 2)
             print(apkVal.packageName)
             this.dismiss()
         }
-        txtAutoRevoke.setOnClickListener{
+        b.txtAutoRevoke.setOnClickListener{
             dbHandler.updatePackage(apkVal.packageName , 1)
             print(apkVal.packageName)
             this.dismiss()
         }
-        txtDoNothing.setOnClickListener{
+        b.txtDoNothing.setOnClickListener{
             dbHandler.updatePackage(apkVal.packageName , 0)
             print(apkVal.packageName)
             this.dismiss()

--- a/app/src/main/java/com/celzero/bravedns/ui/BottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/BottomSheetFragment.kt
@@ -15,8 +15,6 @@ limitations under the License.
 */
 package com.celzero.bravedns.ui
 
-import android.app.Dialog
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -34,31 +32,23 @@ import org.koin.android.ext.android.inject
  * whether to auto remove, auto revoke and do nothing
  * for the permissions.
  */
-class BottomSheetFragment(context : Context, apkItem : Apk) : BottomSheetDialogFragment() {
+class BottomSheetFragment(apkItem: Apk) : BottomSheetDialogFragment() {
     private var _binding: BottomSheetPermissionManagerBinding? = null
     private val b get() = _binding!!
 
-    private var apkVal : Apk = apkItem
+    private var apkVal: Apk = apkItem
     private val dbHandler by inject<DatabaseHandler>()
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-    }
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = BottomSheetPermissionManagerBinding.inflate(inflater, container, false)
         return b.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initView(view)
-    }
-
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        return super.onCreateDialog(savedInstanceState)
+        initView()
     }
 
     override fun onDestroyView() {
@@ -66,37 +56,41 @@ class BottomSheetFragment(context : Context, apkItem : Apk) : BottomSheetDialogF
         _binding = null
     }
 
-    private fun initView(view : View) {
+    private fun initView() {
         print("initView")
-        val rule = 0//HomeScreenActivity.dbHandler.getSpecificPackageRule(apkVal.packageName)
+        val rule = 0 //HomeScreenActivity.dbHandler.getSpecificPackageRule(apkVal.packageName)
         //Toast.makeText(contextV,"Rule:"+rule,Toast.LENGTH_SHORT).show()
 
-        if(rule == 0){
-            b.txtDoNothing.setCompoundDrawablesWithIntrinsicBounds(0,0,R.drawable.ok,0)
-            b.txtAutoRemove.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
-            b.txtAutoRevoke.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
-        }else if(rule == 1){
-            b.txtAutoRevoke.setCompoundDrawablesWithIntrinsicBounds(0,0,R.drawable.ok,0)
-            b.txtAutoRemove.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
-            b.txtDoNothing.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
-        }else if(rule == 2){
-            b.txtAutoRemove.setCompoundDrawablesWithIntrinsicBounds(0,0,R.drawable.ok,0)
-            b.txtAutoRevoke.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
-            b.txtDoNothing.setCompoundDrawablesWithIntrinsicBounds(0,0,0,0)
+        when (rule) {
+            0 -> {
+                b.txtDoNothing.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.ok, 0)
+                b.txtAutoRemove.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
+                b.txtAutoRevoke.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
+            }
+            1 -> {
+                b.txtAutoRevoke.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.ok, 0)
+                b.txtAutoRemove.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
+                b.txtDoNothing.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
+            }
+            2 -> {
+                b.txtAutoRemove.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.ok, 0)
+                b.txtAutoRevoke.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
+                b.txtDoNothing.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0)
+            }
         }
 
-        b.txtAutoRemove.setOnClickListener{
-            dbHandler.updatePackage(apkVal.packageName , 2)
+        b.txtAutoRemove.setOnClickListener {
+            dbHandler.updatePackage(apkVal.packageName, 2)
             print(apkVal.packageName)
             this.dismiss()
         }
-        b.txtAutoRevoke.setOnClickListener{
-            dbHandler.updatePackage(apkVal.packageName , 1)
+        b.txtAutoRevoke.setOnClickListener {
+            dbHandler.updatePackage(apkVal.packageName, 1)
             print(apkVal.packageName)
             this.dismiss()
         }
-        b.txtDoNothing.setOnClickListener{
-            dbHandler.updatePackage(apkVal.packageName , 0)
+        b.txtDoNothing.setOnClickListener {
+            dbHandler.updatePackage(apkVal.packageName, 0)
             print(apkVal.packageName)
             this.dismiss()
         }

--- a/app/src/main/java/com/celzero/bravedns/ui/BottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/BottomSheetFragment.kt
@@ -19,8 +19,10 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.Apk
+import com.celzero.bravedns.databinding.ActivitySettingsScreenBinding
 import com.celzero.bravedns.databinding.BottomSheetPermissionManagerBinding
 import com.celzero.bravedns.util.DatabaseHandler
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -33,27 +35,16 @@ import org.koin.android.ext.android.inject
  * for the permissions.
  */
 class BottomSheetFragment(apkItem: Apk) : BottomSheetDialogFragment() {
-    private var _binding: BottomSheetPermissionManagerBinding? = null
-    private val b get() = _binding!!
+    private val b by viewBinding(BottomSheetPermissionManagerBinding::bind)
 
     private var apkVal: Apk = apkItem
     private val dbHandler by inject<DatabaseHandler>()
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = BottomSheetPermissionManagerBinding.inflate(inflater, container, false)
-        return b.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initView()
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     private fun initView() {

--- a/app/src/main/java/com/celzero/bravedns/ui/ConfigureDNSFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/ConfigureDNSFragment.kt
@@ -79,7 +79,7 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
     private var dnsProxyLayoutManager: RecyclerView.LayoutManager? = null
     private val dnsProxyViewModel: DNSProxyEndpointViewModel by viewModel()
 
-    private lateinit var spinnerAdapter : CustomSpinnerAdapter
+    private lateinit var spinnerAdapter: CustomSpinnerAdapter
 
     private val appInfoRepository by inject<AppInfoRepository>()
     private val dohEndpointRepository by inject<DoHEndpointRepository>()
@@ -97,7 +97,7 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initView(view)
+        initView()
         initClickListeners()
     }
 
@@ -110,7 +110,7 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
         fun newInstance() = ConfigureDNSFragment()
     }
 
-    private fun initView(view: View) {
+    private fun initView() {
         val arraySpinner = requireContext().resources.getStringArray(R.array.dns_endpoint_modes).toList()
 
         spinnerAdapter = CustomSpinnerAdapter(requireContext(), arraySpinner)
@@ -119,11 +119,11 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
         b.configureDnsProgressBar.visibility = View.VISIBLE
 
         HomeScreenActivity.GlobalVariable.median50.observe(viewLifecycleOwner, {
-            b.configureLatencyTxt.setText("Latency: " + HomeScreenActivity.GlobalVariable.median50.value.toString() + "ms")
+            b.configureLatencyTxt.text = "Latency: " + HomeScreenActivity.GlobalVariable.median50.value.toString() + "ms"
         })
 
         //latencyTxt.setText("Latency: " + getMedianLatency(this) + "ms")
-        b.configureTotalQueriesTxt.setText("Lifetime Queries: " + persistentState.getNumOfReq())
+        b.configureTotalQueriesTxt.text = "Lifetime Queries: " + persistentState.getNumOfReq()
 
         //DOH init views
         layoutManager = LinearLayoutManager(requireContext())
@@ -149,17 +149,17 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
         dnsCryptRelayViewModel.dnsCryptRelayEndpointList.observe(viewLifecycleOwner, androidx.lifecycle.Observer(dnsCryptRelayRecyclerAdapter::submitList))
         b.recyclerDnsCryptRelays.adapter = dnsCryptRelayRecyclerAdapter
 
-        dohRecyclerAdapter = DoHEndpointAdapter(requireContext(), dohEndpointRepository,persistentState, get(), this)
+        dohRecyclerAdapter = DoHEndpointAdapter(requireContext(), dohEndpointRepository, persistentState, get(), this)
         viewModel.dohEndpointList.observe(viewLifecycleOwner, androidx.lifecycle.Observer(dohRecyclerAdapter!!::submitList))
         b.recyclerDohConnections.adapter = dohRecyclerAdapter
 
-        dnsProxyRecyclerAdapter = DNSProxyEndpointAdapter(requireContext(), dnsProxyEndpointRepository, persistentState,  get(),this)
+        dnsProxyRecyclerAdapter = DNSProxyEndpointAdapter(requireContext(), dnsProxyEndpointRepository, persistentState, get(), this)
         dnsProxyViewModel.dnsProxyEndpointList.observe(viewLifecycleOwner, androidx.lifecycle.Observer(dnsProxyRecyclerAdapter::submitList))
         b.recyclerDnsProxyConnections.adapter = dnsProxyRecyclerAdapter
 
         if (DEBUG) Log.d(LOG_TAG, "Notify the adapter called ???")
         b.configureDnsProgressBar.visibility = View.GONE
-       val dnsValue= appMode?.getDNSType()
+        val dnsValue = appMode?.getDNSType()
         if (dnsValue == 1) {
             b.configureScreenSpinner.setSelection(0)
 
@@ -171,24 +171,24 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
             b.recyclerDohConnectionsHeader.visibility = View.GONE
             b.recyclerDnsCryptConnectionsHeader.visibility = View.VISIBLE
             b.recyclerDnsProxyConnectionsHeader.visibility = View.GONE
-           /* val cryptDetails = appMode?.getDNSCryptServerCount()
-            connectedTitle.text = resources.getString(R.string.configure_dns_connection_name) + "DNS crypt servers: $cryptDetails"
-            connectedURL.text = resources.getString(R.string.configure_dns_connected_dns_crypt_status)*/
+            /* val cryptDetails = appMode?.getDNSCryptServerCount()
+             connectedTitle.text = resources.getString(R.string.configure_dns_connection_name) + "DNS crypt servers: $cryptDetails"
+             connectedURL.text = resources.getString(R.string.configure_dns_connected_dns_crypt_status)*/
         } else {
             b.configureScreenSpinner.setSelection(2)
             b.recyclerDohConnectionsHeader.visibility = View.GONE
             b.recyclerDnsCryptConnectionsHeader.visibility = View.GONE
             b.recyclerDnsProxyConnectionsHeader.visibility = View.VISIBLE
-           /* val proxyDetails = appMode?.getDNSProxyServerDetails()
-            connectedURL.text = resources.getString(R.string.configure_dns_connected_dns_proxy_status)
-            connectedTitle.text = resources.getString(R.string.configure_dns_connection_name) + proxyDetails?.proxyName*/
+            /* val proxyDetails = appMode?.getDNSProxyServerDetails()
+             connectedURL.text = resources.getString(R.string.configure_dns_connected_dns_proxy_status)
+             connectedTitle.text = resources.getString(R.string.configure_dns_connection_name) + proxyDetails?.proxyName*/
         }
 
         val proxySize = checkProxySize()
         if (proxySize == 0) {
             b.recyclerDnsProxyTitle.visibility = View.VISIBLE
             b.recyclerDnsProxyConnections.visibility = View.GONE
-        }else{
+        } else {
             b.recyclerDnsProxyTitle.visibility = View.GONE
             b.recyclerDnsProxyConnections.visibility = View.VISIBLE
         }
@@ -225,19 +225,23 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
             }
 
             override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
-                if (position == 0) {
-                    b.recyclerDohConnectionsHeader.visibility = View.VISIBLE
-                    b.recyclerDnsCryptConnectionsHeader.visibility = View.GONE
-                    b.recyclerDnsProxyConnectionsHeader.visibility = View.GONE
-                } else if (position == 1) {
-                    Log.d(LOG_TAG, "DNS Crypt on Click event")
-                    b.recyclerDohConnectionsHeader.visibility = View.GONE
-                    b.recyclerDnsCryptConnectionsHeader.visibility = View.VISIBLE
-                    b.recyclerDnsProxyConnectionsHeader.visibility = View.GONE
-                } else if (position == 2) {
-                    b.recyclerDohConnectionsHeader.visibility = View.GONE
-                    b.recyclerDnsCryptConnectionsHeader.visibility = View.GONE
-                    b.recyclerDnsProxyConnectionsHeader.visibility = View.VISIBLE
+                when (position) {
+                    0 -> {
+                        b.recyclerDohConnectionsHeader.visibility = View.VISIBLE
+                        b.recyclerDnsCryptConnectionsHeader.visibility = View.GONE
+                        b.recyclerDnsProxyConnectionsHeader.visibility = View.GONE
+                    }
+                    1 -> {
+                        Log.d(LOG_TAG, "DNS Crypt on Click event")
+                        b.recyclerDohConnectionsHeader.visibility = View.GONE
+                        b.recyclerDnsCryptConnectionsHeader.visibility = View.VISIBLE
+                        b.recyclerDnsProxyConnectionsHeader.visibility = View.GONE
+                    }
+                    2 -> {
+                        b.recyclerDohConnectionsHeader.visibility = View.GONE
+                        b.recyclerDnsCryptConnectionsHeader.visibility = View.GONE
+                        b.recyclerDnsProxyConnectionsHeader.visibility = View.VISIBLE
+                    }
                 }
             }
 
@@ -274,15 +278,15 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
             connectedURL.text = resources.getString(R.string.configure_dns_connected_dns_proxy_status)
             connectedTitle.text = resources.getString(R.string.configure_dns_connection_name) +proxyDetails?.proxyName
         }*/
-        if(DEBUG) Log.d(LOG_TAG, "onResume in fragment")
+        if (DEBUG) Log.d(LOG_TAG, "onResume in fragment")
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        if(DEBUG) Log.d(LOG_TAG, "onActivityResult in fragment")
+        if (DEBUG) Log.d(LOG_TAG, "onActivityResult in fragment")
         super.onActivityResult(requestCode, resultCode, data)
-        if(resultCode == Activity.RESULT_OK){
+        if (resultCode == Activity.RESULT_OK) {
             val stamp = data?.getStringArrayExtra("stamp")
-            if(DEBUG) Log.d(LOG_TAG, "onActivityResult - Stamp : $stamp")
+            if (DEBUG) Log.d(LOG_TAG, "onActivityResult - Stamp : $stamp")
         }
     }
 
@@ -312,15 +316,13 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
         val cancelURLBtn = dialog.findViewById(R.id.dialog_custom_url_cancel_btn) as AppCompatButton
         val customName = dialog.findViewById(R.id.dialog_custom_name_edit_text) as EditText
         val customURL: EditText = dialog.findViewById(R.id.dialog_custom_url_edit_text) as EditText
-        val progressBar: ProgressBar =
-            dialog.findViewById(R.id.dialog_custom_url_loading) as ProgressBar
-        val errorTxt: TextView =
-            dialog.findViewById(R.id.dialog_custom_url_failure_text) as TextView
+        val progressBar: ProgressBar = dialog.findViewById(R.id.dialog_custom_url_loading) as ProgressBar
+        val errorTxt: TextView = dialog.findViewById(R.id.dialog_custom_url_failure_text) as TextView
 
         var count = dohEndpointRepository.getCount()
         count += 1
 
-        customName.setText("DoH $count",TextView.BufferType.EDITABLE)
+        customName.setText("DoH $count", TextView.BufferType.EDITABLE)
         applyURLBtn.setOnClickListener {
             val url = customURL.text.toString()
             val name = customName.text.toString()
@@ -405,8 +407,8 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
         dialog.setCanceledOnTouchOutside(false)
         dialog.window!!.attributes = lp
 
-       /* val radioInternal: RadioButton = dialog.findViewById(R.id.dialog_dns_proxy_radio_internal)
-        val radioExternal: RadioButton = dialog.findViewById(R.id.dialog_dns_proxy_radio_external)*/
+        /* val radioInternal: RadioButton = dialog.findViewById(R.id.dialog_dns_proxy_radio_internal)
+         val radioExternal: RadioButton = dialog.findViewById(R.id.dialog_dns_proxy_radio_external)*/
         val applyURLBtn = dialog.findViewById(R.id.dialog_dns_proxy_apply_btn) as AppCompatButton
         val cancelURLBtn = dialog.findViewById(R.id.dialog_dns_proxy_cancel_btn) as AppCompatButton
         val proxyNameEditText = dialog.findViewById(R.id.dialog_dns_proxy_edit_name) as EditText
@@ -417,16 +419,14 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
         val llSpinnerHeader: LinearLayout = dialog.findViewById(R.id.dialog_dns_proxy_spinner_header)
         val llIPHeader: LinearLayout = dialog.findViewById(R.id.dialog_dns_proxy_ip_header)
 
-        var count  = dnsProxyEndpointRepository.getCount()
+        var count = dnsProxyEndpointRepository.getCount()
         count += 1
         proxyNameEditText.setText("Proxy $count", TextView.BufferType.EDITABLE)
-        ipAddressEditText.setText("127.0.0.1",TextView.BufferType.EDITABLE)
+        ipAddressEditText.setText("127.0.0.1", TextView.BufferType.EDITABLE)
         val appNames: MutableList<String> = ArrayList()
         appNames.add("Nobody")
         appNames.addAll(getAppName())
-        val proxySpinnerAdapter = ArrayAdapter(
-            requireContext(), android.R.layout.simple_spinner_dropdown_item, appNames
-        )
+        val proxySpinnerAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_dropdown_item, appNames)
         appNameSpinner.adapter = proxySpinnerAdapter
         //radioInternal.isChecked = true
         llSpinnerHeader.visibility = View.VISIBLE
@@ -481,18 +481,18 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
                         errorTxt.text = "Port range should be from 1024-65535"
                         isValid = false
                     }
-                }else{
+                } else {
                     isValid = true
                 }
             } catch (e: Exception) {
                 Log.e(LOG_TAG, "Error: ${e.message}", e)
-                errorTxt.setText("Invalid port")
+                errorTxt.text = "Invalid port"
                 isValid = false
             }
 
             if (isValid && isIPValid) {
                 //Do the DNS Proxy setting there
-                if(DEBUG) Log.d(LOG_TAG, "Insert into DNSProxy")
+                if (DEBUG) Log.d(LOG_TAG, "Insert into DNSProxy")
                 insertDNSProxyEndpointDB(mode, name, appName, ip, port)
                 b.recyclerDnsProxyTitle.visibility = View.GONE
                 b.recyclerDnsProxyConnections.visibility = View.VISIBLE
@@ -512,15 +512,14 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
     private fun insertDNSProxyEndpointDB(mode: String, name: String, appName: String, ip: String, port: Int) {
         var proxyName = name
         if (proxyName.isEmpty() || proxyName.isBlank()) {
-            if (mode == "Internal") {
-                proxyName = appName
-            } else
-                proxyName = ip
+            proxyName = if (mode == "Internal") {
+                appName
+            } else ip
         }
         //id: Int, proxyName: String,  proxyType: String, proxyAppName: String, proxyIP: String,proxyPort : Int, isSelected: Boolean, isCustom: Boolean, modifiedDataTime: Long, latency: Int
         val dnsProxyEndpoint = DNSProxyEndpoint(-1, proxyName, mode, appName, ip, port, false, true, 0L, 0)
         dnsProxyEndpointRepository.insertAsync(dnsProxyEndpoint)
-        if(DEBUG) Log.d(LOG_TAG, "Insert into DNSProxy - $appName, $port")
+        if (DEBUG) Log.d(LOG_TAG, "Insert into DNSProxy - $appName, $port")
         object : CountDownTimer(500, 500) {
             override fun onTick(millisUntilFinished: Long) {
             }
@@ -561,16 +560,16 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
         count += 1
         cryptNameEditText.setText("DNSCrypt $count", TextView.BufferType.EDITABLE)
 
-        radioServer.setOnClickListener{
+        radioServer.setOnClickListener {
             var count = dnsCryptEndpointRepository.getCount()
-            count +=1
-            cryptNameEditText.setText("DNSCrypt $count",  TextView.BufferType.EDITABLE)
+            count += 1
+            cryptNameEditText.setText("DNSCrypt $count", TextView.BufferType.EDITABLE)
         }
 
-        radioRelay.setOnClickListener{
+        radioRelay.setOnClickListener {
             var count = dnsCryptRelayEndpointRepository.getCount()
             count += 1
-            cryptNameEditText.setText("DNSRelay $count",  TextView.BufferType.EDITABLE)
+            cryptNameEditText.setText("DNSRelay $count", TextView.BufferType.EDITABLE)
         }
 
         applyURLBtn.setOnClickListener {
@@ -669,8 +668,7 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
     private fun checkUrl(url: String): Boolean {
         return try {
             val parsed = URL(url)
-            parsed.protocol == "https" && parsed.host.isNotEmpty() &&
-                    parsed.path.isNotEmpty() && parsed.query == null && parsed.ref == null
+            parsed.protocol == "https" && parsed.host.isNotEmpty() && parsed.path.isNotEmpty() && parsed.query == null && parsed.ref == null
         } catch (e: MalformedURLException) {
             false
         }
@@ -692,9 +690,9 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
     }
 
     override fun updateUIFromAdapter(dnsType: Int) {
-        if(DEBUG) Log.d(LOG_TAG, "UI Update from adapter")
+        if (DEBUG) Log.d(LOG_TAG, "UI Update from adapter")
         if (dnsType == 1) {
-            if(DEBUG) Log.d(LOG_TAG, "DOH has been changed, modify the connection status in the top layout")
+            if (DEBUG) Log.d(LOG_TAG, "DOH has been changed, modify the connection status in the top layout")
             dnsCryptEndpointRepository.removeConnectionStatus()
             dnsCryptRelayEndpointRepository.removeConnectionStatus()
             dnsProxyEndpointRepository.removeConnectionStatus()
@@ -715,7 +713,7 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
             dohRecyclerAdapter?.notifyDataSetChanged()
             dnsCryptRecyclerAdapter.notifyDataSetChanged()
             dnsCryptRelayRecyclerAdapter.notifyDataSetChanged()
-        } else if(dnsType == 4){
+        } else if (dnsType == 4) {
             val proxySize = checkProxySize()
             if (proxySize == 0) {
                 b.recyclerDnsProxyTitle.visibility = View.VISIBLE

--- a/app/src/main/java/com/celzero/bravedns/ui/ConfigureDNSFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/ConfigureDNSFragment.kt
@@ -29,6 +29,7 @@ import androidx.appcompat.widget.AppCompatButton
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.*
 import com.celzero.bravedns.database.*
@@ -55,9 +56,8 @@ import java.net.MalformedURLException
 import java.net.URL
 
 
-class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
-    private var _binding: FragmentConfigureDnsBinding? = null
-    private val b get() = _binding!!
+class ConfigureDNSFragment : Fragment(R.layout.fragment_configure_dns), UIUpdateInterface {
+    private val b by viewBinding(FragmentConfigureDnsBinding::bind)
 
     //DOH UI elements
     private var layoutManager: RecyclerView.LayoutManager? = null
@@ -89,21 +89,10 @@ class ConfigureDNSFragment : Fragment(), UIUpdateInterface {
     private val doHEndpointRepository by inject<DoHEndpointRepository>()
     private val persistentState by inject<PersistentState>()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        super.onCreate(savedInstanceState)
-        _binding = FragmentConfigureDnsBinding.inflate(inflater, container, false)
-        return b.root
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         initView()
         initClickListeners()
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     companion object {

--- a/app/src/main/java/com/celzero/bravedns/ui/ConnTrackerBottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/ConnTrackerBottomSheetFragment.kt
@@ -44,6 +44,7 @@ import com.celzero.bravedns.automaton.FirewallManager
 import com.celzero.bravedns.automaton.FirewallRules
 import com.celzero.bravedns.data.ConnectionRules
 import com.celzero.bravedns.database.*
+import com.celzero.bravedns.databinding.BottomSheetConnTrackBinding
 import com.celzero.bravedns.service.BraveVPNService
 import com.celzero.bravedns.service.PersistentState
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
@@ -66,31 +67,12 @@ import org.koin.android.ext.android.inject
  * TODO : Need to move the strings to strings.xml file.
  */
 class ConnTrackerBottomSheetFragment(private var contextVal: Context, private var ipDetails: ConnectionTracker) : BottomSheetDialogFragment() {
+    private var _binding: BottomSheetConnTrackBinding? = null
+    private val b get() = _binding!!
 
-    private var fragmentView: View? = null
-
-    private lateinit var txtRule1: TextView
     //private lateinit var txtRule2: TextView
-    private lateinit var txtRule3: TextView
 
-    private lateinit var appNameHeaderRL : RelativeLayout
-
-    private lateinit var txtAppName: TextView
-    private lateinit var txtAppBlock: TextView
-    private lateinit var txtConnDetails: TextView
-    private lateinit var txtConnectionIP: TextView
-    private lateinit var txtFlag: TextView
-    private lateinit var imgAppIcon: ImageView
-
-    private lateinit var rule1HeaderLL : LinearLayout
-    private lateinit var rule1HeaderTxt : TextView
-
-    private lateinit var switchBlockApp: SwitchCompat
     //private lateinit var switchBlockConnApp: SwitchCompat
-    private lateinit var switchBlockConnAll: SwitchCompat
-
-    private lateinit var chipKillApp: Chip
-    private lateinit var chipClearRules: Chip
 
     private lateinit var firewallRules: FirewallRules
 
@@ -114,59 +96,42 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
     private val categoryInfoRepository: CategoryInfoRepository by inject()
     private val persistentState by inject<PersistentState>()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        fragmentView = inflater.inflate(R.layout.bottom_sheet_conn_track, container, false)
-        return fragmentView
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = BottomSheetConnTrackBinding.inflate(inflater, container, false)
+        return b.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initView(view)
+        initView()
     }
 
 
-    private fun initView(view: View) {
-        txtAppName = view.findViewById(R.id.bs_conn_track_app_name)
-        imgAppIcon = view.findViewById(R.id.bs_conn_track_app_icon)
-
-        rule1HeaderLL = view.findViewById(R.id.bs_conn_blocked_rule1_header_ll)
-        rule1HeaderTxt = view.findViewById(R.id.bs_conn_blocked_rule1_txt)
-
-        txtRule1 = view.findViewById(R.id.bs_conn_block_app_txt)
-        txtRule3 = view.findViewById(R.id.bs_conn_block_conn_all_txt)
-
-        txtAppBlock = view.findViewById(R.id.bs_conn_blocked_desc)
-        txtConnDetails = view.findViewById(R.id.bs_conn_connection_details)
-
-        appNameHeaderRL = view.findViewById(R.id.bs_conn_track_app_name_header)
-
-        txtConnectionIP = view.findViewById(R.id.bs_conn_connection_type_heading)
-        txtFlag = view.findViewById(R.id.bs_conn_connection_flag)
-
-        chipKillApp = view.findViewById(R.id.bs_conn_track_app_kill)
-        chipClearRules = view.findViewById(R.id.bs_conn_track_app_clear_rules)
-
-        switchBlockApp = view.findViewById(R.id.bs_conn_block_app_check)
-        switchBlockConnAll = view.findViewById(R.id.bs_conn_block_conn_all_switch)
+    private fun initView() {
         //switchBlockConnApp = view.findViewById(R.id.bs_conn_block_conn_app_switch)
 
         val protocol = Protocol.getProtocolName(ipDetails.protocol).name
 
-        txtConnectionIP.text = ipDetails.ipAddress!!
-        txtFlag.text = ipDetails.flag.toString()
+        b.bsConnConnectionTypeHeading.text = ipDetails.ipAddress!!
+        b.bsConnConnectionFlag.text = ipDetails.flag.toString()
 
         var _text = getString(R.string.bsct_block)
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-            txtRule1.text  = Html.fromHtml(_text, FROM_HTML_MODE_LEGACY)
+            b.bsConnBlockAppTxt.text  = Html.fromHtml(_text, FROM_HTML_MODE_LEGACY)
         } else {
-            txtRule1.text  = Html.fromHtml(_text)
+            b.bsConnBlockAppTxt.text  = Html.fromHtml(_text)
         }
 
         _text = getString(R.string.bsct_block_all)
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-            txtRule3.text = Html.fromHtml(_text, FROM_HTML_MODE_LEGACY)
+            b.bsConnBlockConnAllTxt.text = Html.fromHtml(_text, FROM_HTML_MODE_LEGACY)
         }else{
-            txtRule3.text = Html.fromHtml(_text)
+            b.bsConnBlockConnAllTxt.text = Html.fromHtml(_text)
         }
 
         val time = DateUtils.getRelativeTimeSpanString(ipDetails.timeStamp, System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE)
@@ -175,27 +140,27 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
             try {
                 val appArray = contextVal.packageManager.getPackagesForUid(ipDetails.uid)
                 val appCount = (appArray?.size)?.minus(1)
-                txtAppName.text = ipDetails.appName +"      ❯"
+                b.bsConnTrackAppName.text = ipDetails.appName +"      ❯"
                 if(appArray != null) {
                     if (appArray?.size!! > 2) {
-                        txtAppName.text = "${ipDetails.appName} + $appCount other apps"
+                        b.bsConnTrackAppName.text = "${ipDetails.appName} + $appCount other apps"
                         //chipKillApp.text = "Kill all ${appCount?.plus(1)} apps"
-                        chipKillApp.visibility = View.GONE
+                        b.bsConnTrackAppKill.visibility = View.GONE
                     } else if (appArray.size == 2) {
-                        txtAppName.text = "${ipDetails.appName} + $appCount other app"
+                        b.bsConnTrackAppName.text = "${ipDetails.appName} + $appCount other app"
                         //chipKillApp.text = "Kill ${appCount?.plus(1)} apps"
-                        chipKillApp.visibility = View.GONE
+                        b.bsConnTrackAppKill.visibility = View.GONE
                     }
-                    imgAppIcon.setImageDrawable(contextVal.packageManager.getApplicationIcon(appArray[0]!!))
+                    b.bsConnTrackAppIcon.setImageDrawable(contextVal.packageManager.getApplicationIcon(appArray[0]!!))
                 }
             } catch (e: Exception) {
                 Log.e(LOG_TAG, "Package Not Found - " + e.message, e)
             }
         }else{
-            txtAppName.text = "Unknown"
-            chipKillApp.visibility = View.GONE
-            rule1HeaderTxt.text = "Rule #5"
-            txtRule1.text = contextVal.resources.getString(R.string.univ_block_unknown_connections)
+            b.bsConnTrackAppName.text = "Unknown"
+            b.bsConnTrackAppKill.visibility = View.GONE
+            b.bsConnBlockedRule1Txt .text = "Rule #5"
+            b.bsConnBlockAppTxt.text = contextVal.resources.getString(R.string.univ_block_unknown_connections)
         }
 
         val listBlocked = blockedConnectionsRepository.getAllBlockedConnectionsForUID(ipDetails.uid)
@@ -204,7 +169,7 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
                 switchBlockConnAll.isChecked = true
             }else*/
             if(it.ruleType == (BraveVPNService.BlockedRuleNames.RULE2.ruleName) && ipDetails.ipAddress.equals(it.ipAddress) && it.uid == UNIVERSAL_RULES_UID){
-                switchBlockConnAll.isChecked = true
+                b.bsConnBlockConnAllSwitch.isChecked = true
             }
         }
 
@@ -213,54 +178,54 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
         isRuleBlocked = firewallRules.checkRules(ipDetails.uid, connRules)
         isRuleUniversal = firewallRules.checkRules(UNIVERSAL_RULES_UID, connRules)
 
-        switchBlockApp.setOnCheckedChangeListener(null)
-        switchBlockApp.setOnClickListener {
+        b.bsConnBlockAppCheck.setOnCheckedChangeListener(null)
+        b.bsConnBlockAppCheck.setOnClickListener {
             if (ipDetails.uid == 0) {
-                switchBlockApp.isChecked = false
+                b.bsConnBlockAppCheck.isChecked = false
                 Utilities.showToastInMidLayout(contextVal, "Android cannot be firewalled", Toast.LENGTH_SHORT)
             } else if (ipDetails.appName != "Unknown") {
                 // no-op?
             } else {
-                if(DEBUG) Log.d(LOG_TAG,"setBlockUnknownConnections - ${switchBlockApp.isChecked} ")
-                persistentState.blockUnknownConnections = switchBlockApp.isChecked
+                if(DEBUG) Log.d(LOG_TAG,"setBlockUnknownConnections - ${b.bsConnBlockAppCheck.isChecked} ")
+                persistentState.blockUnknownConnections = b.bsConnBlockAppCheck.isChecked
             }
         }
 
         if (ipDetails.isBlocked) {
-            chipKillApp.visibility = View.VISIBLE
-            chipKillApp.text = ipDetails.blockedByRule
+            b.bsConnTrackAppKill.visibility = View.VISIBLE
+            b.bsConnTrackAppKill.text = ipDetails.blockedByRule
             _text = getString(R.string.bsct_conn_conn_desc_blocked, protocol, ipDetails.port.toString(), time)
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-                txtConnDetails.text = Html.fromHtml(_text, FROM_HTML_MODE_COMPACT)
+                b.bsConnConnectionDetails.text = Html.fromHtml(_text, FROM_HTML_MODE_COMPACT)
             }else{
-                txtConnDetails.text = Html.fromHtml(_text)
+                b.bsConnConnectionDetails.text = Html.fromHtml(_text)
             }
         } else {
             _text = getString(R.string.bsct_conn_conn_desc_allowed,  protocol, ipDetails.port.toString(), time)
-            chipKillApp.visibility = View.GONE
+            b.bsConnTrackAppKill.visibility = View.GONE
             if(ipDetails.blockedByRule.equals(BraveVPNService.BlockedRuleNames.RULE7.ruleName)){
-                chipKillApp.visibility = View.VISIBLE
-                chipKillApp.text = "Whitelisted"
+                b.bsConnTrackAppKill.visibility = View.VISIBLE
+                b.bsConnTrackAppKill.text = "Whitelisted"
             }
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-                txtConnDetails.text = Html.fromHtml(_text, FROM_HTML_MODE_LEGACY)
+                b.bsConnConnectionDetails.text = Html.fromHtml(_text, FROM_HTML_MODE_LEGACY)
             }else{
-                txtConnDetails.text = Html.fromHtml(_text)
+                b.bsConnConnectionDetails.text = Html.fromHtml(_text)
             }
         }
 
         if (ipDetails.appName != "Unknown") {
-            switchBlockApp.isChecked = isAppBlocked
+            b.bsConnBlockAppCheck.isChecked = isAppBlocked
         }else{
-            switchBlockApp.isChecked = persistentState.blockUnknownConnections
+            b.bsConnBlockAppCheck.isChecked = persistentState.blockUnknownConnections
         }
 
-        chipKillApp.setOnClickListener{
+        b.bsConnTrackAppKill.setOnClickListener{
             showDialogForInfo()
         }
 
-        switchBlockConnAll.setOnCheckedChangeListener(null)
-        switchBlockConnAll.setOnClickListener {
+        b.bsConnBlockConnAllSwitch.setOnCheckedChangeListener(null)
+        b.bsConnBlockConnAllSwitch.setOnClickListener {
             if (isRuleUniversal) {
                 if (DEBUG) Log.d(LOG_TAG, "Universal Remove - ${connRules.ipAddress}, ${BraveVPNService.BlockedRuleNames.RULE2.ruleName}")
                 firewallRules.removeFirewallRules(UNIVERSAL_RULES_UID, connRules.ipAddress, BraveVPNService.BlockedRuleNames.RULE2.ruleName, blockedConnectionsRepository)
@@ -272,10 +237,10 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
                 isRuleUniversal = true
                 Utilities.showToastInMidLayout(contextVal, "Blocking all connections to ${connRules.ipAddress}", Toast.LENGTH_SHORT)
             }
-            switchBlockConnAll.isChecked = isRuleUniversal
+            b.bsConnBlockConnAllSwitch.isChecked = isRuleUniversal
         }
 
-        appNameHeaderRL.setOnClickListener {
+        b.bsConnTrackAppNameHeader.setOnClickListener {
             try {
                 val appUIDList = appInfoRepository.getAppListForUID(ipDetails.uid)
                 if (appUIDList.size == 1) {
@@ -293,7 +258,7 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
             }
         }
 
-        chipClearRules.setOnClickListener {
+        b.bsConnTrackAppClearRules.setOnClickListener {
             clearAppRules()
         }
     }
@@ -317,11 +282,11 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
         if(!appUIDList.isNullOrEmpty()) {
             if (appUIDList[0].whiteListUniv1) {
                 Utilities.showToastInMidLayout(contextVal, getString(R.string.bsct_firewall_not_available_whitelist), Toast.LENGTH_SHORT)
-                switchBlockApp.isChecked = false
+                b.bsConnBlockAppCheck.isChecked = false
                 return
             } else if (appUIDList[0].isExcluded) {
                 Utilities.showToastInMidLayout(contextVal, getString(R.string.bsct_firewall_not_available_excluded), Toast.LENGTH_SHORT)
-                switchBlockApp.isChecked = false
+                b.bsConnBlockAppCheck.isChecked = false
                 return
             }
             if (appUIDList.size > 1) {
@@ -346,11 +311,11 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
                     appInfoRepository.updateInternetForuid(uid, isBlocked)
                 }
             } else {
-                switchBlockApp.isChecked = isBlocked
+                b.bsConnBlockAppCheck.isChecked = isBlocked
             }
         }else{
             Utilities.showToastInMidLayout(contextVal, getString(R.string.firewall_app_info_not_available), Toast.LENGTH_SHORT)
-            switchBlockApp.isChecked = false
+            b.bsConnBlockAppCheck.isChecked = false
         }
     }
 

--- a/app/src/main/java/com/celzero/bravedns/ui/ConnTrackerBottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/ConnTrackerBottomSheetFragment.kt
@@ -35,9 +35,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
-import android.widget.*
+import android.widget.ArrayAdapter
+import android.widget.ImageView
+import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.widget.SwitchCompat
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
 import com.celzero.bravedns.R
 import com.celzero.bravedns.automaton.FirewallManager
@@ -52,7 +54,6 @@ import com.celzero.bravedns.util.Constants.Companion.LOG_TAG
 import com.celzero.bravedns.util.Protocol
 import com.celzero.bravedns.util.Utilities
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import com.google.android.material.chip.Chip
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -122,15 +123,15 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
 
         var _text = getString(R.string.bsct_block)
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-            b.bsConnBlockAppTxt.text  = Html.fromHtml(_text, FROM_HTML_MODE_LEGACY)
+            b.bsConnBlockAppTxt.text = Html.fromHtml(_text, FROM_HTML_MODE_LEGACY)
         } else {
-            b.bsConnBlockAppTxt.text  = Html.fromHtml(_text)
+            b.bsConnBlockAppTxt.text = Html.fromHtml(_text)
         }
 
         _text = getString(R.string.bsct_block_all)
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
             b.bsConnBlockConnAllTxt.text = Html.fromHtml(_text, FROM_HTML_MODE_LEGACY)
-        }else{
+        } else {
             b.bsConnBlockConnAllTxt.text = Html.fromHtml(_text)
         }
 
@@ -140,9 +141,9 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
             try {
                 val appArray = contextVal.packageManager.getPackagesForUid(ipDetails.uid)
                 val appCount = (appArray?.size)?.minus(1)
-                b.bsConnTrackAppName.text = ipDetails.appName +"      ❯"
-                if(appArray != null) {
-                    if (appArray?.size!! > 2) {
+                b.bsConnTrackAppName.text = ipDetails.appName + "      ❯"
+                if (appArray != null) {
+                    if (appArray.size > 2) {
                         b.bsConnTrackAppName.text = "${ipDetails.appName} + $appCount other apps"
                         //chipKillApp.text = "Kill all ${appCount?.plus(1)} apps"
                         b.bsConnTrackAppKill.visibility = View.GONE
@@ -156,19 +157,19 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
             } catch (e: Exception) {
                 Log.e(LOG_TAG, "Package Not Found - " + e.message, e)
             }
-        }else{
+        } else {
             b.bsConnTrackAppName.text = "Unknown"
             b.bsConnTrackAppKill.visibility = View.GONE
-            b.bsConnBlockedRule1Txt .text = "Rule #5"
+            b.bsConnBlockedRule1Txt.text = "Rule #5"
             b.bsConnBlockAppTxt.text = contextVal.resources.getString(R.string.univ_block_unknown_connections)
         }
 
         val listBlocked = blockedConnectionsRepository.getAllBlockedConnectionsForUID(ipDetails.uid)
-        listBlocked.forEach{
+        listBlocked.forEach {
             /*if(it.ruleType == (BraveVPNService.BlockedRuleNames.RULE2.ruleName) && ipDetails.ipAddress.equals(it.ipAddress) && ipDetails.uid == it.uid){
                 switchBlockConnAll.isChecked = true
             }else*/
-            if(it.ruleType == (BraveVPNService.BlockedRuleNames.RULE2.ruleName) && ipDetails.ipAddress.equals(it.ipAddress) && it.uid == UNIVERSAL_RULES_UID){
+            if (it.ruleType == (BraveVPNService.BlockedRuleNames.RULE2.ruleName) && ipDetails.ipAddress.equals(it.ipAddress) && it.uid == UNIVERSAL_RULES_UID) {
                 b.bsConnBlockConnAllSwitch.isChecked = true
             }
         }
@@ -186,7 +187,7 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
             } else if (ipDetails.appName != "Unknown") {
                 // no-op?
             } else {
-                if(DEBUG) Log.d(LOG_TAG,"setBlockUnknownConnections - ${b.bsConnBlockAppCheck.isChecked} ")
+                if (DEBUG) Log.d(LOG_TAG, "setBlockUnknownConnections - ${b.bsConnBlockAppCheck.isChecked} ")
                 persistentState.blockUnknownConnections = b.bsConnBlockAppCheck.isChecked
             }
         }
@@ -197,30 +198,30 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
             _text = getString(R.string.bsct_conn_conn_desc_blocked, protocol, ipDetails.port.toString(), time)
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
                 b.bsConnConnectionDetails.text = Html.fromHtml(_text, FROM_HTML_MODE_COMPACT)
-            }else{
+            } else {
                 b.bsConnConnectionDetails.text = Html.fromHtml(_text)
             }
         } else {
-            _text = getString(R.string.bsct_conn_conn_desc_allowed,  protocol, ipDetails.port.toString(), time)
+            _text = getString(R.string.bsct_conn_conn_desc_allowed, protocol, ipDetails.port.toString(), time)
             b.bsConnTrackAppKill.visibility = View.GONE
-            if(ipDetails.blockedByRule.equals(BraveVPNService.BlockedRuleNames.RULE7.ruleName)){
+            if (ipDetails.blockedByRule.equals(BraveVPNService.BlockedRuleNames.RULE7.ruleName)) {
                 b.bsConnTrackAppKill.visibility = View.VISIBLE
                 b.bsConnTrackAppKill.text = "Whitelisted"
             }
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
                 b.bsConnConnectionDetails.text = Html.fromHtml(_text, FROM_HTML_MODE_LEGACY)
-            }else{
+            } else {
                 b.bsConnConnectionDetails.text = Html.fromHtml(_text)
             }
         }
 
         if (ipDetails.appName != "Unknown") {
             b.bsConnBlockAppCheck.isChecked = isAppBlocked
-        }else{
+        } else {
             b.bsConnBlockAppCheck.isChecked = persistentState.blockUnknownConnections
         }
 
-        b.bsConnTrackAppKill.setOnClickListener{
+        b.bsConnTrackAppKill.setOnClickListener {
             showDialogForInfo()
         }
 
@@ -279,7 +280,7 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
     private fun firewallApp(isBlocked: Boolean) {
         var blockAllApps = false
         val appUIDList = appInfoRepository.getAppListForUID(ipDetails.uid)
-        if(!appUIDList.isNullOrEmpty()) {
+        if (!appUIDList.isNullOrEmpty()) {
             if (appUIDList[0].whiteListUniv1) {
                 Utilities.showToastInMidLayout(contextVal, getString(R.string.bsct_firewall_not_available_whitelist), Toast.LENGTH_SHORT)
                 b.bsConnBlockAppCheck.isChecked = false
@@ -313,7 +314,7 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
             } else {
                 b.bsConnBlockAppCheck.isChecked = isBlocked
             }
-        }else{
+        } else {
             Utilities.showToastInMidLayout(contextVal, getString(R.string.firewall_app_info_not_available), Toast.LENGTH_SHORT)
             b.bsConnBlockAppCheck.isChecked = false
         }
@@ -370,7 +371,7 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
         val descText = dialog.findViewById(R.id.info_rules_dialog_rules_desc) as TextView
 
         var text = getString(R.string.bsct_conn_rule_explanation)
-        text = text.replace("\n","<br /><br />")
+        text = text.replace("\n", "<br /><br />")
         val styledText = Html.fromHtml(text)
         descText.text = styledText
 
@@ -386,8 +387,7 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
      */
     private fun showDialog(packageList: List<AppInfo>, appName: String, title: String, positiveText: String): Boolean {
         //Change the handler logic into some other
-        val handler: Handler = @SuppressLint("HandlerLeak")
-        object : Handler() {
+        val handler: Handler = @SuppressLint("HandlerLeak") object : Handler() {
             override fun handleMessage(mesg: Message) {
                 throw RuntimeException()
             }
@@ -407,14 +407,10 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
         builderSingle.setCancelable(false)
         builderSingle.setItems(packageNameList.toTypedArray(), null)
 
-        builderSingle.setPositiveButton(
-            positiveTxt
-        ) { _: DialogInterface, _: Int ->
+        builderSingle.setPositiveButton(positiveTxt) { _: DialogInterface, _: Int ->
             proceedBlocking = true
             handler.sendMessage(handler.obtainMessage())
-        }.setNeutralButton(
-            "Go Back"
-        ) { _: DialogInterface, _: Int ->
+        }.setNeutralButton("Go Back") { _: DialogInterface, _: Int ->
             handler.sendMessage(handler.obtainMessage())
             proceedBlocking = false
         }

--- a/app/src/main/java/com/celzero/bravedns/ui/ConnTrackerBottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/ConnTrackerBottomSheetFragment.kt
@@ -31,9 +31,7 @@ import android.text.Html
 import android.text.Html.FROM_HTML_MODE_LEGACY
 import android.text.format.DateUtils
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.Window
 import android.widget.ArrayAdapter
 import android.widget.ImageView
@@ -41,6 +39,7 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.automaton.FirewallManager
 import com.celzero.bravedns.automaton.FirewallRules
@@ -68,8 +67,7 @@ import org.koin.android.ext.android.inject
  * TODO : Need to move the strings to strings.xml file.
  */
 class ConnTrackerBottomSheetFragment(private var contextVal: Context, private var ipDetails: ConnectionTracker) : BottomSheetDialogFragment() {
-    private var _binding: BottomSheetConnTrackBinding? = null
-    private val b get() = _binding!!
+    private val b by viewBinding(BottomSheetConnTrackBinding::bind)
 
     //private lateinit var txtRule2: TextView
 
@@ -96,16 +94,6 @@ class ConnTrackerBottomSheetFragment(private var contextVal: Context, private va
     private val blockedConnectionsRepository: BlockedConnectionsRepository by inject()
     private val categoryInfoRepository: CategoryInfoRepository by inject()
     private val persistentState by inject<PersistentState>()
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = BottomSheetConnTrackBinding.inflate(inflater, container, false)
-        return b.root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/celzero/bravedns/ui/ConnTrackerBottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/ConnTrackerBottomSheetFragment.kt
@@ -31,7 +31,9 @@ import android.text.Html
 import android.text.Html.FROM_HTML_MODE_LEGACY
 import android.text.format.DateUtils
 import android.util.Log
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.view.Window
 import android.widget.ArrayAdapter
 import android.widget.ImageView
@@ -39,7 +41,6 @@ import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
-import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.automaton.FirewallManager
 import com.celzero.bravedns.automaton.FirewallRules
@@ -67,17 +68,27 @@ import org.koin.android.ext.android.inject
  * TODO : Need to move the strings to strings.xml file.
  */
 class ConnTrackerBottomSheetFragment(private var contextVal: Context, private var ipDetails: ConnectionTracker) : BottomSheetDialogFragment() {
-    private val b by viewBinding(BottomSheetConnTrackBinding::bind)
+    private var _binding: BottomSheetConnTrackBinding? = null
 
-    //private lateinit var txtRule2: TextView
-
-    //private lateinit var switchBlockConnApp: SwitchCompat
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val b get() = _binding!!
 
     private lateinit var firewallRules: FirewallRules
 
     private var isAppBlocked: Boolean = false
     private var isRuleBlocked: Boolean = false
     private var isRuleUniversal: Boolean = false
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = BottomSheetConnTrackBinding.inflate(inflater, container, false)
+        return b.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/celzero/bravedns/ui/ConnectionTrackerFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/ConnectionTrackerFragment.kt
@@ -20,9 +20,6 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
-import android.widget.LinearLayout
-import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
@@ -31,6 +28,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.ConnectionTrackerAdapter
 import com.celzero.bravedns.database.ConnectionTrackerDAO
+import com.celzero.bravedns.databinding.ActivityConnectionTrackerBinding
 import com.celzero.bravedns.service.PersistentState
 import com.celzero.bravedns.util.Constants.Companion.LOG_TAG
 import com.celzero.bravedns.viewmodel.ConnectionTrackerViewModel
@@ -47,14 +45,10 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
  * Database table name - ConnectionTracker.
  */
 class ConnectionTrackerFragment : Fragment(), SearchView.OnQueryTextListener {
+    private var _binding: ActivityConnectionTrackerBinding? = null
+    private val b get() = _binding!!
 
-    private var recyclerView: RecyclerView? = null
     private var layoutManager: RecyclerView.LayoutManager? = null
-    private var editSearchView: SearchView? = null
-    private lateinit var searchLayoutLL : LinearLayout
-    private lateinit var filterIcon: ImageView
-    private lateinit var deleteIcon: ImageView
-    private lateinit var disabledLogsTextView: TextView
     private var recyclerAdapter: ConnectionTrackerAdapter? = null
     private val viewModel: ConnectionTrackerViewModel by viewModel()
     private var filterValue: String = ""
@@ -63,58 +57,53 @@ class ConnectionTrackerFragment : Fragment(), SearchView.OnQueryTextListener {
     private val connectionTrackerDAO by inject<ConnectionTrackerDAO>()
     private val persistentState by inject<PersistentState>()
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         super.onCreate(savedInstanceState)
-        return inflater.inflate(R.layout.activity_connection_tracker, container, false)
+        _binding = ActivityConnectionTrackerBinding.inflate(inflater, container, false)
+        return b.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initView(view)
+        initView()
     }
 
-    companion object{
+    companion object {
         fun newInstance() = ConnectionTrackerFragment()
     }
 
-    private fun initView(view: View) {
-        val includeView = view.findViewById<View>(R.id.connection_list_scroll_list)
-        recyclerView = includeView.findViewById<View>(R.id.recycler_connection) as RecyclerView
-        editSearchView = includeView.findViewById(R.id.connection_search)
-        filterIcon = includeView.findViewById(R.id.connection_filter_icon)
-        deleteIcon = includeView.findViewById(R.id.connection_delete_icon)
-        searchLayoutLL = includeView.findViewById(R.id.connection_card_view_top)
-        disabledLogsTextView = includeView.findViewById(R.id.connection_list_logs_disabled_tv)
+    private fun initView() {
+        val includeView = b.connectionListScrollList
 
-        if(persistentState.logsEnabled){
-            disabledLogsTextView.visibility = View.GONE
-            searchLayoutLL.visibility = View.VISIBLE
+        if (persistentState.logsEnabled) {
+            includeView.connectionListLogsDisabledTv.visibility = View.GONE
+            includeView.connectionCardViewTop.visibility = View.VISIBLE
 
-            recyclerView!!.setHasFixedSize(true)
+            includeView.recyclerConnection.setHasFixedSize(true)
             layoutManager = LinearLayoutManager(requireContext())
-            recyclerView!!.layoutManager = layoutManager
+            includeView.recyclerConnection.layoutManager = layoutManager
 
             recyclerAdapter = ConnectionTrackerAdapter(requireContext())
             viewModel.connectionTrackerList.observe(viewLifecycleOwner, androidx.lifecycle.Observer(recyclerAdapter!!::submitList))
-            recyclerView!!.adapter = recyclerAdapter
+            includeView.recyclerConnection.adapter = recyclerAdapter
             //recyclerView!!.setItemViewCacheSize(100)
-        }else{
-            disabledLogsTextView.visibility = View.VISIBLE
-            searchLayoutLL.visibility = View.GONE
+        } else {
+            includeView.connectionListLogsDisabledTv.visibility = View.VISIBLE
+            includeView.connectionCardViewTop.visibility = View.GONE
         }
 
 
-        editSearchView!!.setOnQueryTextListener(this)
-        editSearchView!!.setOnClickListener {
-            editSearchView!!.requestFocus()
-            editSearchView!!.onActionViewExpanded()
+        includeView.connectionSearch.setOnQueryTextListener(this)
+        includeView.connectionSearch.setOnClickListener {
+            includeView.connectionSearch.requestFocus()
+            includeView.connectionSearch.onActionViewExpanded()
         }
 
-        filterIcon.setOnClickListener {
+        includeView.connectionFilterIcon.setOnClickListener {
             showDialogForFilter()
         }
 
-        deleteIcon.setOnClickListener {
+        includeView.connectionDeleteIcon.setOnClickListener {
             showDialogForDelete()
         }
 
@@ -122,7 +111,7 @@ class ConnectionTrackerFragment : Fragment(), SearchView.OnQueryTextListener {
     }
 
     override fun onQueryTextSubmit(query: String?): Boolean {
-        viewModel.setFilter(query!!,filterValue)
+        viewModel.setFilter(query!!, filterValue)
         return true
     }
 

--- a/app/src/main/java/com/celzero/bravedns/ui/ConnectionTrackerFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/ConnectionTrackerFragment.kt
@@ -17,14 +17,13 @@ package com.celzero.bravedns.ui
 
 import android.os.Bundle
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.ConnectionTrackerAdapter
 import com.celzero.bravedns.database.ConnectionTrackerDAO
@@ -44,9 +43,8 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
  * Live data is used to fetch the network details from the database.
  * Database table name - ConnectionTracker.
  */
-class ConnectionTrackerFragment : Fragment(), SearchView.OnQueryTextListener {
-    private var _binding: ActivityConnectionTrackerBinding? = null
-    private val b get() = _binding!!
+class ConnectionTrackerFragment : Fragment(R.layout.activity_connection_tracker), SearchView.OnQueryTextListener {
+    private val b by viewBinding(ActivityConnectionTrackerBinding::bind)
 
     private var layoutManager: RecyclerView.LayoutManager? = null
     private var recyclerAdapter: ConnectionTrackerAdapter? = null
@@ -56,12 +54,6 @@ class ConnectionTrackerFragment : Fragment(), SearchView.OnQueryTextListener {
 
     private val connectionTrackerDAO by inject<ConnectionTrackerDAO>()
     private val persistentState by inject<PersistentState>()
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        super.onCreate(savedInstanceState)
-        _binding = ActivityConnectionTrackerBinding.inflate(inflater, container, false)
-        return b.root
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -130,10 +122,8 @@ class ConnectionTrackerFragment : Fragment(), SearchView.OnQueryTextListener {
         // Single-choice items (initialized with checked item)
         builder.setSingleChoiceItems(singleItems, checkedItem) { dialog, which ->
             // Respond to item chosen
-            filterValue = if (which == 0)
-                ":isFilter"
-            else
-                ""
+            filterValue = if (which == 0) ":isFilter"
+            else ""
             checkedItem = which
             if (HomeScreenActivity.GlobalVariable.DEBUG) Log.d(LOG_TAG, "Filter Option selected: $filterValue")
             viewModel.setFilterBlocked(filterValue)

--- a/app/src/main/java/com/celzero/bravedns/ui/DNSBlockListBottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/DNSBlockListBottomSheetFragment.kt
@@ -23,21 +23,37 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
+import by.kirich1409.viewbindingdelegate.dialogViewBinding
 import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.DNSBottomSheetBlockAdapter
 import com.celzero.bravedns.database.DNSLogs
 import com.celzero.bravedns.databinding.BottomSheetConnTrackBinding
 import com.celzero.bravedns.databinding.BottomSheetDnsLogBinding
+import com.celzero.bravedns.databinding.FragmentFilterAndSortBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 
 class DNSBlockListBottomSheetFragment(private var contextVal: Context, private var transaction: DNSLogs) : BottomSheetDialogFragment() {
-    private val b by viewBinding(BottomSheetDnsLogBinding::bind)
+    private var _binding: BottomSheetDnsLogBinding? = null
+
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val b get() = _binding!!
 
     private lateinit var recyclerAdapter: DNSBottomSheetBlockAdapter
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = BottomSheetDnsLogBinding.inflate(inflater, container, false)
+        return b.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/celzero/bravedns/ui/DNSBlockListBottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/DNSBlockListBottomSheetFragment.kt
@@ -40,6 +40,7 @@ class DNSBlockListBottomSheetFragment(private var contextVal: Context, private v
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         b.dnsBlockUrl.text = transaction.queryStr
         b.dnsBlockIpAddress.text = transaction.response
         b.dnsBlockConnectionFlag.text = transaction.flag
@@ -95,8 +96,6 @@ class DNSBlockListBottomSheetFragment(private var contextVal: Context, private v
                 b.dnsBlockPlaceHolder.visibility = View.VISIBLE
             }
         }
-
-        super.onViewCreated(view, savedInstanceState)
     }
 
 }

--- a/app/src/main/java/com/celzero/bravedns/ui/DNSBlockListBottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/DNSBlockListBottomSheetFragment.kt
@@ -22,121 +22,90 @@ import android.text.format.DateUtils
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.RelativeLayout
-import android.widget.TextView
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.DNSBottomSheetBlockAdapter
 import com.celzero.bravedns.database.DNSLogs
+import com.celzero.bravedns.databinding.BottomSheetDnsLogBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 
-class DNSBlockListBottomSheetFragment(private var contextVal: Context, private var transaction: DNSLogs)  : BottomSheetDialogFragment() {
+class DNSBlockListBottomSheetFragment(private var contextVal: Context, private var transaction: DNSLogs) : BottomSheetDialogFragment() {
+    private var _binding: BottomSheetDnsLogBinding? = null
+    private val b get() = _binding!!
 
-    private lateinit var fragmentView: View
-    private lateinit var dnsBlockRecyclerView: RecyclerView
-    private lateinit var recyclerAdapter : DNSBottomSheetBlockAdapter
-    private lateinit var urlTxt : TextView
-    private lateinit var flagTxt : TextView
-    private lateinit var resolverTxt : TextView
-    private lateinit var ipAddressTxt : TextView
-    private lateinit var blockedDescTxt : TextView
-    private lateinit var placeHolderTxt : TextView
-    private lateinit var latencyTxt : TextView
-    private lateinit var latencyChipTxt : TextView
-
-    private lateinit var dnsBlockContainerRL : RelativeLayout
-
-    private lateinit var txtView : TextView
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-    }
+    private lateinit var recyclerAdapter: DNSBottomSheetBlockAdapter
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        fragmentView = inflater.inflate(R.layout.bottom_sheet_dns_log, container, false)
-        initView(fragmentView)
-        return fragmentView
+        _binding = BottomSheetDnsLogBinding.inflate(inflater, container, false)
+        return b.root
     }
 
-    private fun initView(fragmentView: View) {
-        urlTxt = fragmentView.findViewById(R.id.dns_block_url)
-        ipAddressTxt = fragmentView.findViewById(R.id.dns_block_ip_address)
-        resolverTxt = fragmentView.findViewById(R.id.dns_block_resolver)
-        flagTxt = fragmentView.findViewById(R.id.dns_block_connection_flag)
-        dnsBlockContainerRL = fragmentView.findViewById(R.id.dns_block_recycler_container)
-        dnsBlockRecyclerView = fragmentView.findViewById(R.id.dns_block_recyclerview)
-        txtView = fragmentView.findViewById(R.id.dns_block_btm_sheet)
-        blockedDescTxt = fragmentView.findViewById(R.id.dns_block_blocked_desc)
-        placeHolderTxt = fragmentView.findViewById(R.id.dns_block_place_holder)
-        latencyTxt = fragmentView.findViewById(R.id.dns_block_latency)
-        latencyChipTxt = fragmentView.findViewById(R.id.dns_block_ip_latency)
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        urlTxt.text = transaction.queryStr
-        ipAddressTxt.text = transaction.response
-        flagTxt.text = transaction.flag
+        b.dnsBlockUrl.text = transaction.queryStr
+        b.dnsBlockIpAddress.text = transaction.response
+        b.dnsBlockConnectionFlag.text = transaction.flag
         //latencyTxt.text = "Latency: "+transaction.latency
-        latencyTxt.visibility = View.GONE
-        latencyChipTxt.text = transaction.latency.toString() +"ms"
-        if(transaction.serverIP.isNotEmpty()) {
-            resolverTxt.visibility = View.VISIBLE
-            resolverTxt.text = "Resolver (${transaction.serverIP})"
-            resolverTxt.visibility = View.GONE
-        }else{
-            resolverTxt.visibility = View.GONE
+        b.dnsBlockLatency.visibility = View.GONE
+        b.dnsBlockIpLatency.text = transaction.latency.toString() + "ms"
+        if (transaction.serverIP.isNotEmpty()) {
+            b.dnsBlockResolver.visibility = View.VISIBLE
+            b.dnsBlockResolver.text = "Resolver (${transaction.serverIP})"
+            b.dnsBlockResolver.visibility = View.GONE
+        } else {
+            b.dnsBlockResolver.visibility = View.GONE
         }
         val upTime = DateUtils.getRelativeTimeSpanString(transaction.time, System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE)
-        if(transaction.isBlocked){
-            blockedDescTxt.text = "blocked $upTime by ${transaction.serverIP}"
-        }else{
-            if(transaction.serverIP.isNotEmpty() && transaction.relayIP.isNotEmpty()) {
-                var styledText= ""
+        if (transaction.isBlocked) {
+            b.dnsBlockBlockedDesc.text = "blocked $upTime by ${transaction.serverIP}"
+        } else {
+            if (transaction.serverIP.isNotEmpty() && transaction.relayIP.isNotEmpty()) {
+                var styledText = ""
                 val text = "resolved <u>anonymously</u> $upTime by ${transaction.serverIP}"
                 if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
                     styledText = Html.fromHtml(text, Html.FROM_HTML_MODE_LEGACY).toString()
                 } else {
                     styledText = Html.fromHtml(text).toString()
                 }
-                blockedDescTxt.text = styledText
-            }else if(transaction.serverIP.isNotEmpty()){
-                blockedDescTxt.text = "resolved $upTime by ${transaction.serverIP}"
-            }
-            else{
-                blockedDescTxt.text = "resolved $upTime"
+                b.dnsBlockBlockedDesc.text = styledText
+            } else if (transaction.serverIP.isNotEmpty()) {
+                b.dnsBlockBlockedDesc.text = "resolved $upTime by ${transaction.serverIP}"
+            } else {
+                b.dnsBlockBlockedDesc.text = "resolved $upTime"
             }
         }
-        if(transaction.blockLists.isEmpty()){
-            dnsBlockContainerRL.visibility = View.GONE
-            placeHolderTxt.visibility = View.VISIBLE
-        }else{
-            if(transaction.serverIP.isEmpty()){
-                blockedDescTxt.text = getString(R.string.bsct_conn_block_desc, upTime, " on device")
-            }else{
-                blockedDescTxt.text = getString(R.string.bsct_conn_block_desc, upTime," by ${transaction.serverIP}")
+        if (transaction.blockLists.isEmpty()) {
+            b.dnsBlockRecyclerContainer.visibility = View.GONE
+            b.dnsBlockPlaceHolder.visibility = View.VISIBLE
+        } else {
+            if (transaction.serverIP.isEmpty()) {
+                b.dnsBlockBlockedDesc.text = getString(R.string.bsct_conn_block_desc, upTime, " on device")
+            } else {
+                b.dnsBlockBlockedDesc.text = getString(R.string.bsct_conn_block_desc, upTime, " by ${transaction.serverIP}")
             }
 
             //blockedDescTxt.text = "blocked " + upTime
             val blockLists = transaction.blockLists.split(",")
             if (blockLists != null) {
                 //placeHolderTxt.visibility = View.GONE
-                dnsBlockRecyclerView.layoutManager = LinearLayoutManager(contextVal)
+                b.dnsBlockRecyclerview.layoutManager = LinearLayoutManager(contextVal)
                 recyclerAdapter = DNSBottomSheetBlockAdapter(contextVal, blockLists)
-                dnsBlockRecyclerView.adapter = recyclerAdapter
+                b.dnsBlockRecyclerview.adapter = recyclerAdapter
                 //dnsBlockRecyclerView.addItemDecoration(DividerItemDecoration(contextVal, DividerItemDecoration.VERTICAL))
-                placeHolderTxt.visibility = View.GONE
-            }else{
-                placeHolderTxt.visibility = View.VISIBLE
+                b.dnsBlockPlaceHolder.visibility = View.GONE
+            } else {
+                b.dnsBlockPlaceHolder.visibility = View.VISIBLE
             }
         }
 
         super.onViewCreated(view, savedInstanceState)
     }
-
-
 
 }

--- a/app/src/main/java/com/celzero/bravedns/ui/DNSBlockListBottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/DNSBlockListBottomSheetFragment.kt
@@ -23,30 +23,21 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.DNSBottomSheetBlockAdapter
 import com.celzero.bravedns.database.DNSLogs
+import com.celzero.bravedns.databinding.BottomSheetConnTrackBinding
 import com.celzero.bravedns.databinding.BottomSheetDnsLogBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 
 class DNSBlockListBottomSheetFragment(private var contextVal: Context, private var transaction: DNSLogs) : BottomSheetDialogFragment() {
-    private var _binding: BottomSheetDnsLogBinding? = null
-    private val b get() = _binding!!
+    private val b by viewBinding(BottomSheetDnsLogBinding::bind)
 
     private lateinit var recyclerAdapter: DNSBottomSheetBlockAdapter
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = BottomSheetDnsLogBinding.inflate(inflater, container, false)
-        return b.root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         b.dnsBlockUrl.text = transaction.queryStr

--- a/app/src/main/java/com/celzero/bravedns/ui/DNSConfigureWebViewActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/DNSConfigureWebViewActivity.kt
@@ -24,8 +24,10 @@ import android.net.Uri
 import android.net.http.SslError
 import android.os.Bundle
 import android.os.CountDownTimer
+import android.util.AttributeSet
 import android.util.Log
 import android.view.KeyEvent
+import android.view.View
 import android.webkit.*
 import android.webkit.WebView.RENDERER_PRIORITY_BOUND
 import android.widget.ProgressBar
@@ -33,8 +35,10 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.MutableLiveData
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.database.DoHEndpointRepository
+import com.celzero.bravedns.databinding.ActivityAppDetailsBinding
 import com.celzero.bravedns.databinding.ActivityFaqWebviewLayoutBinding
 import com.celzero.bravedns.service.PersistentState
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
@@ -55,8 +59,8 @@ import java.io.File
 import java.io.IOException
 
 
-class DNSConfigureWebViewActivity : AppCompatActivity() {
-    private lateinit var b: ActivityFaqWebviewLayoutBinding
+class DNSConfigureWebViewActivity : AppCompatActivity(R.layout.activity_faq_webview_layout) {
+    private val b by viewBinding(ActivityFaqWebviewLayoutBinding::bind)
     private val MAX_PROGRESS = 100
     private var stamp: String? = ""
     private var url: String = Constants.CONFIGURE_BLOCKLIST_URL_REMOTE //"https://bravedns.com/configure?v=app"
@@ -79,8 +83,6 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
 
     @SuppressLint("SetJavaScriptEnabled") override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        b = ActivityFaqWebviewLayoutBinding.inflate(layoutInflater)
-        setContentView(b.root)
         context = this
         downloadManager = context.getSystemService(DOWNLOAD_SERVICE) as DownloadManager
         receivedIntentFrom = intent.getIntExtra("location", 0)

--- a/app/src/main/java/com/celzero/bravedns/ui/DNSConfigureWebViewActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/DNSConfigureWebViewActivity.kt
@@ -35,6 +35,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.MutableLiveData
 import com.celzero.bravedns.R
 import com.celzero.bravedns.database.DoHEndpointRepository
+import com.celzero.bravedns.databinding.ActivityFaqWebviewLayoutBinding
 import com.celzero.bravedns.service.PersistentState
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
 import com.celzero.bravedns.util.Constants
@@ -55,22 +56,20 @@ import java.io.IOException
 
 
 class DNSConfigureWebViewActivity : AppCompatActivity() {
-
-    private var dnsConfigureWebView: WebView?= null
-    private lateinit var progressBar: ProgressBar
+    private lateinit var b: ActivityFaqWebviewLayoutBinding
     private val MAX_PROGRESS = 100
-    private var stamp : String? = ""
-    private var url : String = Constants.CONFIGURE_BLOCKLIST_URL_REMOTE //"https://bravedns.com/configure?v=app"
-    private var receivedStamp : String = ""
-    private var blockListsCount : MutableLiveData<Int> = MutableLiveData()
-    private lateinit var context : Context
-    private lateinit var downloadManager : DownloadManager
-    private var timeStamp : Long = 0L
-    private var receivedIntentFrom : Int = 0
+    private var stamp: String? = ""
+    private var url: String = Constants.CONFIGURE_BLOCKLIST_URL_REMOTE //"https://bravedns.com/configure?v=app"
+    private var receivedStamp: String = ""
+    private var blockListsCount: MutableLiveData<Int> = MutableLiveData()
+    private lateinit var context: Context
+    private lateinit var downloadManager: DownloadManager
+    private var timeStamp: Long = 0L
+    private var receivedIntentFrom: Int = 0
     private val doHEndpointRepository by inject<DoHEndpointRepository>()
     private val persistentState by inject<PersistentState>()
 
-    companion object{
+    companion object {
         const val LOCAL = 1
         const val REMOTE = 2
         var enqueue: Long = 0
@@ -78,29 +77,27 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
     }
 
 
-    @SuppressLint("SetJavaScriptEnabled")
-    override fun onCreate(savedInstanceState: Bundle?) {
+    @SuppressLint("SetJavaScriptEnabled") override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_faq_webview_layout)
-        dnsConfigureWebView = findViewById(R.id.configure_webview)
-        progressBar = findViewById(R.id.progressBar)
+        b = ActivityFaqWebviewLayoutBinding.inflate(layoutInflater)
+        setContentView(b.root)
         context = this
         downloadManager = context.getSystemService(DOWNLOAD_SERVICE) as DownloadManager
         receivedIntentFrom = intent.getIntExtra("location", 0)
         stamp = intent.getStringExtra("stamp")
-        try{
+        try {
             initWebView()
             setWebClient()
             if (stamp != null && stamp!!.isNotEmpty()) {
-                if(receivedIntentFrom == LOCAL) {
+                if (receivedIntentFrom == LOCAL) {
                     url = Constants.CONFIGURE_BLOCKLIST_URL_LOCAL + persistentState.localBlockListDownloadTime + "#" + stamp
-                }else{
+                } else {
                     url = Constants.CONFIGURE_BLOCKLIST_URL_REMOTE + persistentState.remoteBlockListDownloadTime + "#" + stamp
                     checkForDownload()
                 }
             }
             Log.d(LOG_TAG, "Webview:  - url - $url")
-        }catch (e: Exception){
+        } catch (e: Exception) {
             Log.i(LOG_TAG, "Webview: Exception: ${e.message}", e)
             showDialogOnError(null)
         }
@@ -109,7 +106,7 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
         blockListsCount.observe(this, {
             if (receivedIntentFrom == LOCAL) {
                 persistentState.numberOfLocalBlocklists = it!!
-            }else{
+            } else {
                 persistentState.numberOfRemoteBlocklists = it!!
             }
 
@@ -121,20 +118,19 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        if(DEBUG) Log.d(LOG_TAG, "Webview: onDestroy")
+        if (DEBUG) Log.d(LOG_TAG, "Webview: onDestroy")
 
-        if(receivedIntentFrom == LOCAL){
+        if (receivedIntentFrom == LOCAL) {
             updateLocalStamp()
-        }else if(receivedIntentFrom == REMOTE) {
+        } else if (receivedIntentFrom == REMOTE) {
             updateDoHEndPoint()
         }
-        dnsConfigureWebView?.removeJavascriptInterface("JSInterface")
-        dnsConfigureWebView?.removeAllViews()
+        b.configureWebview.removeJavascriptInterface("JSInterface")
+        b.configureWebview.removeAllViews()
         /*dnsConfigureWebView?.clearCache(true)
         dnsConfigureWebView?.clearFormData()*/
-        dnsConfigureWebView?.clearHistory()
-        dnsConfigureWebView?.destroy()
-        dnsConfigureWebView = null
+        b.configureWebview.clearHistory()
+        b.configureWebview.destroy()
 
         /*val intent = Intent()
         intent.putExtra("stamp", receivedStamp)
@@ -167,54 +163,51 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
         Toast.makeText(this, "Configured URL has been updated successfully", Toast.LENGTH_SHORT).show()
     }
 
-    private fun updateLocalStamp(){
+    private fun updateLocalStamp() {
         //if(receivedStamp.isNotEmpty()) {
-            Log.i(LOG_TAG, "Webview: Local stamp has been set from webview - $receivedStamp")
-            if(receivedStamp.isEmpty() || receivedStamp == "https://basic.bravedns.com/"){
-                val localStamp = persistentState.getLocalBlockListStamp()
-                if(localStamp?.isNotEmpty()!!){
-                    return
-                }
-                persistentState.setLocalBlockListStamp("")
+        Log.i(LOG_TAG, "Webview: Local stamp has been set from webview - $receivedStamp")
+        if (receivedStamp.isEmpty() || receivedStamp == "https://basic.bravedns.com/") {
+            val localStamp = persistentState.getLocalBlockListStamp()
+            if (localStamp.isNotEmpty()) {
                 return
             }
-            //PersistentState.setNumberOfLocalBlockLists(this, blockListsCount.value!!)
-            val stamp = Xdns.getBlocklistStampFromURL(receivedStamp)
-            if(DEBUG) Log.d(LOG_TAG, "Split stamp - $stamp")
-            val context = this
-            val path: String = this.filesDir.canonicalPath
-            if (HomeScreenActivity.GlobalVariable.appMode?.getBraveDNS() == null) {
-                GlobalScope.launch(Dispatchers.IO) {
-                    val braveDNS = Dnsx.newBraveDNSLocal(path + Constants.FILE_TD_FILE, path + Constants.FILE_RD_FILE, path + Constants.FILE_BASIC_CONFIG, path + Constants.FILE_TAG_NAME)
-                    HomeScreenActivity.GlobalVariable.appMode?.setBraveDNSMode(braveDNS)
-                    persistentState.setLocalBlockListStamp(stamp)
-                    if(DEBUG) Log.d(LOG_TAG, "Webview: Local brave dns set call from web view -stamp: $stamp")
-                }
-            }else{
-                GlobalScope.launch(Dispatchers.IO) {
-                    //val braveDNS = Dnsx.newBraveDNSLocal(path + Constants.FILE_TD_FILE, path + Constants.FILE_RD_FILE, path + Constants.FILE_BASIC_CONFIG, path + Constants.FILE_TAG_NAME)
-                    //HomeScreenActivity.GlobalVariable.appMode?.setBraveDNSMode(braveDNS)
-                    persistentState.setLocalBlockListStamp(stamp)
-                    if (DEBUG) Log.d(LOG_TAG, "Webview: Local brave dns set call from web view -stamp: $stamp")
-                }
+            persistentState.setLocalBlockListStamp("")
+            return
+        }
+        //PersistentState.setNumberOfLocalBlockLists(this, blockListsCount.value!!)
+        val stamp = Xdns.getBlocklistStampFromURL(receivedStamp)
+        if (DEBUG) Log.d(LOG_TAG, "Split stamp - $stamp")
+        val context = this
+        val path: String = this.filesDir.canonicalPath
+        if (HomeScreenActivity.GlobalVariable.appMode?.getBraveDNS() == null) {
+            GlobalScope.launch(Dispatchers.IO) {
+                val braveDNS = Dnsx.newBraveDNSLocal(path + Constants.FILE_TD_FILE, path + Constants.FILE_RD_FILE, path + Constants.FILE_BASIC_CONFIG, path + Constants.FILE_TAG_NAME)
+                HomeScreenActivity.GlobalVariable.appMode?.setBraveDNSMode(braveDNS)
+                persistentState.setLocalBlockListStamp(stamp)
+                if (DEBUG) Log.d(LOG_TAG, "Webview: Local brave dns set call from web view -stamp: $stamp")
             }
-            Toast.makeText(this, "Local blocklists updated successfully", Toast.LENGTH_SHORT).show()
+        } else {
+            GlobalScope.launch(Dispatchers.IO) {
+                //val braveDNS = Dnsx.newBraveDNSLocal(path + Constants.FILE_TD_FILE, path + Constants.FILE_RD_FILE, path + Constants.FILE_BASIC_CONFIG, path + Constants.FILE_TAG_NAME)
+                //HomeScreenActivity.GlobalVariable.appMode?.setBraveDNSMode(braveDNS)
+                persistentState.setLocalBlockListStamp(stamp)
+                if (DEBUG) Log.d(LOG_TAG, "Webview: Local brave dns set call from web view -stamp: $stamp")
+            }
+        }
+        Toast.makeText(this, "Local blocklists updated successfully", Toast.LENGTH_SHORT).show()
         //}
     }
 
     private fun setWebClient() {
-        dnsConfigureWebView?.webChromeClient = object : WebChromeClient() {
-            override fun onProgressChanged(
-                view: WebView,
-                newProgress: Int
-            ) {
+        b.configureWebview.webChromeClient = object : WebChromeClient() {
+            override fun onProgressChanged(view: WebView, newProgress: Int) {
                 super.onProgressChanged(view, newProgress)
-                progressBar.progress = newProgress
-                if (newProgress < MAX_PROGRESS && progressBar.visibility == ProgressBar.GONE) {
-                    progressBar.visibility = ProgressBar.VISIBLE
+                b.progressBar.progress = newProgress
+                if (newProgress < MAX_PROGRESS && b.progressBar.visibility == ProgressBar.GONE) {
+                    b.progressBar.visibility = ProgressBar.VISIBLE
                 }
                 if (newProgress == MAX_PROGRESS) {
-                    progressBar.visibility = ProgressBar.GONE
+                    b.progressBar.visibility = ProgressBar.GONE
                 }
             }
 
@@ -224,18 +217,18 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
     override fun onKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
         // Check if the key event was the Back button and if there's history
         if (keyCode == KeyEvent.KEYCODE_BACK) {
-            if(DEBUG) Log.d(LOG_TAG, "Webview: WebView- onBack pressed")
-            if(!dnsConfigureWebView?.url!!.contains("bravedns.com/configure")){
+            if (DEBUG) Log.d(LOG_TAG, "Webview: WebView- onBack pressed")
+            if (!b.configureWebview.url!!.contains("bravedns.com/configure")) {
                 //return super.onKeyDown(keyCode, event)
-                dnsConfigureWebView?.goBack()
+                b.configureWebview.goBack()
             } else if (receivedStamp.isEmpty()) {
                 showDialogForExitWebView()
                 //Toast.makeText(this, "Blocklist not set", Toast.LENGTH_SHORT).show()
-            }else{
+            } else {
                 return super.onKeyDown(keyCode, event)
             }
             //return false
-            if(DEBUG) Log.d(LOG_TAG, "Webview: URL : ${dnsConfigureWebView?.url}")
+            if (DEBUG) Log.d(LOG_TAG, "Webview: URL : ${b.configureWebview.url}")
         }
         // If it wasn't the Back key or there's no web page history, exit the activity)
         return false
@@ -248,27 +241,27 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
         //set title for alert dialog
         builder.setTitle(R.string.webview_no_stamp_change_title)
         //set message for alert dialog
-        val desc = if(receivedIntentFrom == LOCAL) {
+        val desc = if (receivedIntentFrom == LOCAL) {
             getString(R.string.webview_no_stamp_change_desc, count.toString())
-        }else{
+        } else {
             getString(R.string.webview_no_stamp_change_remote)
         }
         builder.setMessage(desc)
         builder.setIcon(android.R.drawable.ic_dialog_alert)
         builder.setCancelable(true)
         //performing positive action
-        builder.setPositiveButton("Quit") { dialogInterface, which ->
+        builder.setPositiveButton("Quit") { dialogInterface, _ ->
             dialogInterface.dismiss()
             finish()
         }
 
         //performing negative action
-        builder.setNegativeButton("Go Back") { dialogInterface, which ->
+        builder.setNegativeButton("Go Back") { dialogInterface, _ ->
             dialogInterface.dismiss()
         }
 
-        builder.setNeutralButton("Reload"){ dialogInterface: DialogInterface, i: Int ->
-            dnsConfigureWebView?.reload()
+        builder.setNeutralButton("Reload") { _: DialogInterface, _: Int ->
+            b.configureWebview.reload()
         }
         // Create the AlertDialog
         val alertDialog: AlertDialog = builder.create()
@@ -277,20 +270,18 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
         alertDialog.show()
     }
 
-    @SuppressLint("SetJavaScriptEnabled")
-    private fun initWebView() {
-        dnsConfigureWebView?.settings!!.javaScriptEnabled = true
-        dnsConfigureWebView?.settings!!.loadWithOverviewMode = true
-        dnsConfigureWebView?.settings!!.useWideViewPort = true
+    @SuppressLint("SetJavaScriptEnabled") private fun initWebView() {
+        b.configureWebview.settings.javaScriptEnabled = true
+        b.configureWebview.settings.loadWithOverviewMode = true
+        b.configureWebview.settings.useWideViewPort = true
         //dnsConfigureWebView?.settings!!.domStorageEnabled = true
         //dnsConfigureWebView?.settings!!.cacheMode = LOAD_NO_CACHE
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
-            dnsConfigureWebView?.setRendererPriorityPolicy(RENDERER_PRIORITY_BOUND, true)
+            b.configureWebview.setRendererPriorityPolicy(RENDERER_PRIORITY_BOUND, true)
         }
-        context  = this
-        dnsConfigureWebView?.webViewClient = object : WebViewClient() {
-            override
-            fun onReceivedSslError(view: WebView?, handler: SslErrorHandler?, error: SslError?) {
+        context = this
+        b.configureWebview.webViewClient = object : WebViewClient() {
+            override fun onReceivedSslError(view: WebView?, handler: SslErrorHandler?, error: SslError?) {
                 Log.i(LOG_TAG, "Webview: SSL error received from webview. Finishing the webview with toast. ${error?.primaryError}, ${handler?.obtainMessage()}")
                 showDialogOnError(handler)
             }
@@ -306,10 +297,7 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
                         // Renderer was killed because the system ran out of memory.
                         // The app can recover gracefully by creating a new WebView instance
                         // in the foreground.
-                        Log.e(
-                            LOG_TAG,
-                            ("Webview: System killed the WebView rendering process Recreating...")
-                        )
+                        Log.e(LOG_TAG, ("Webview: System killed the WebView rendering process Recreating..."))
 
                         view?.also { webView ->
                             webView.destroy()
@@ -336,19 +324,19 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
 
         }
 
-        dnsConfigureWebView?.addJavascriptInterface(JSInterface(), "JSInterface")
+        b.configureWebview.addJavascriptInterface(JSInterface(), "JSInterface")
     }
 
     private fun loadUrl(pageUrl: String) {
         try {
-            dnsConfigureWebView?.post {
+            b.configureWebview.post {
                 run {
-                    dnsConfigureWebView?.loadUrl(pageUrl)
+                    b.configureWebview.loadUrl(pageUrl)
                 }
             }
 
             //dnsConfigureWebView?.loadUrl(pageUrl)
-        }catch (e: Exception){
+        } catch (e: Exception) {
             Log.e(LOG_TAG, "Web view: Issue while loading url: ${e.message}", e)
             showDialogOnError(null)
         }
@@ -365,16 +353,16 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
         builder.setIcon(android.R.drawable.ic_dialog_alert)
         builder.setCancelable(true)
         //performing positive action
-        builder.setPositiveButton("Reload") { dialogInterface, which ->
-            if(handler != null){
+        builder.setPositiveButton("Reload") { _, _ ->
+            if (handler != null) {
                 handler.proceed()
-            }else {
-                dnsConfigureWebView?.reload()
+            } else {
+                b.configureWebview.reload()
             }
         }
 
         //performing negative action
-        builder.setNegativeButton("Cancel") { dialogInterface, which ->
+        builder.setNegativeButton("Cancel") { dialogInterface, _ ->
             if (handler != null) {
                 handler.cancel()
             } else {
@@ -392,20 +380,18 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
 
     inner class JSInterface {
 
-        @JavascriptInterface
-        fun setDnsUrl(stamp: String, count: Long) {
+        @JavascriptInterface fun setDnsUrl(stamp: String, count: Long) {
             if (stamp.isEmpty()) {
                 receivedStamp = "https://basic.bravedns.com/"
             }
             receivedStamp = stamp
 
             blockListsCount.postValue(count.toInt())
-            if(DEBUG) Log.d(LOG_TAG, "Webview: - Stamp value - $receivedStamp, $count")
+            if (DEBUG) Log.d(LOG_TAG, "Webview: - Stamp value - $receivedStamp, $count")
             finish()
         }
 
-        @JavascriptInterface
-        fun dismiss(reason: String){
+        @JavascriptInterface fun dismiss(reason: String) {
             Log.i(LOG_TAG, "Webview:  dismiss with reason - $reason")
             finish()
         }
@@ -444,7 +430,7 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
                             val from = File(ctxt.getExternalFilesDir(null).toString() + Constants.DOWNLOAD_PATH + Constants.FILE_TAG_NAME)
                             val to = File(ctxt.filesDir.canonicalPath + Constants.FILE_TAG_NAME)
                             val fileDownloaded = from.copyTo(to, true)
-                            if(fileDownloaded.exists()) {
+                            if (fileDownloaded.exists()) {
                                 Utilities.deleteOldFiles(ctxt)
                             }
                             //val destDir = File(ctxt.filesDir.canonicalPath)
@@ -453,7 +439,7 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
                         } else {
                             Log.e(LOG_TAG, "Webview: Error downloading filetag.json file: $status")
                         }
-                    }else{
+                    } else {
                         Log.e(LOG_TAG, "Webview: Download status: Error downloading filetag.json file: ${c.count}")
                     }
                     c.close()
@@ -470,16 +456,15 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
             //Register or UnRegister your broadcast receiver here
             this.unregisterReceiver(onComplete)
         } catch (e: IllegalArgumentException) {
-            Log.w(LOG_TAG,"Unregister receiver exception")
+            Log.w(LOG_TAG, "Unregister receiver exception")
         }
     }
 
     private fun downloadBlockListFiles() {
         registerReceiverForDownloadManager()
-        if(timeStamp == 0L)
-            timeStamp = persistentState.remoteBlockListDownloadTime
+        if (timeStamp == 0L) timeStamp = persistentState.remoteBlockListDownloadTime
         val url = Constants.JSON_DOWNLOAD_BLOCKLIST_LINK + "/" + timeStamp
-        if(DEBUG) Log.d(LOG_TAG, "Webview: download filetag file with url: $url")
+        if (DEBUG) Log.d(LOG_TAG, "Webview: download filetag file with url: $url")
         val uri: Uri = Uri.parse(url)
         val request = DownloadManager.Request(uri)
         request.setDestinationInExternalFilesDir(this, Constants.DOWNLOAD_PATH, Constants.FILE_TAG_NAME)
@@ -497,9 +482,7 @@ class DNSConfigureWebViewActivity : AppCompatActivity() {
 
     private fun run(url: String) {
         val client = OkHttpClient()
-        val request = Request.Builder()
-            .url(url)
-            .build()
+        val request = Request.Builder().url(url).build()
 
         client.newCall(request).enqueue(object : Callback {
             override fun onFailure(call: Call, e: IOException) {

--- a/app/src/main/java/com/celzero/bravedns/ui/DNSDetailActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/DNSDetailActivity.kt
@@ -25,27 +25,23 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.celzero.bravedns.R
+import com.celzero.bravedns.databinding.ActivityDnsDetailBinding
 import com.celzero.bravedns.util.Constants.Companion.LOG_TAG
-import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 
 class DNSDetailActivity : AppCompatActivity() {
-    private lateinit var viewPagerDNS: ViewPager2
-    private lateinit var tabLayoutFirewall: TabLayout
+    private lateinit var b: ActivityDnsDetailBinding
     private val DNS_TABS_COUNT = 2
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_dns_detail)
+        b = ActivityDnsDetailBinding.inflate(layoutInflater)
+        setContentView(b.root)
         init()
     }
 
     private fun init() {
-
-        viewPagerDNS = findViewById(R.id.dns_detail_act_viewpager)
-        tabLayoutFirewall = findViewById(R.id.dns_detail_act_tabLayout)
-
-        viewPagerDNS.adapter = object : FragmentStateAdapter(this) {
+        b.dnsDetailActViewpager.adapter = object : FragmentStateAdapter(this) {
             override fun createFragment(position: Int): Fragment {
                 return when (position) {
                     0 -> DNSLogFragment.newInstance()
@@ -58,17 +54,17 @@ class DNSDetailActivity : AppCompatActivity() {
             }
         }
 
-        TabLayoutMediator(tabLayoutFirewall, viewPagerDNS) { tab, position -> // Styling each tab here
+        TabLayoutMediator(b.dnsDetailActTabLayout, b.dnsDetailActViewpager) { tab, position -> // Styling each tab here
             tab.text = when (position) {
                 0 -> getString(R.string.dns_act_log)
                 else -> getString(R.string.dns_act_configure_tab)
             }
-            viewPagerDNS.setCurrentItem(tab.position, true)
+            b.dnsDetailActViewpager.setCurrentItem(tab.position, true)
         }.attach()
 
         val recyclerViewField = ViewPager2::class.java.getDeclaredField("mRecyclerView")
         recyclerViewField.isAccessible = true
-        val recyclerView = recyclerViewField.get(viewPagerDNS) as RecyclerView
+        val recyclerView = recyclerViewField.get(b.dnsDetailActViewpager) as RecyclerView
 
         val touchSlopField = RecyclerView::class.java.getDeclaredField("mTouchSlop")
         touchSlopField.isAccessible = true

--- a/app/src/main/java/com/celzero/bravedns/ui/DNSDetailActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/DNSDetailActivity.kt
@@ -24,19 +24,18 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.databinding.ActivityDnsDetailBinding
 import com.celzero.bravedns.util.Constants.Companion.LOG_TAG
 import com.google.android.material.tabs.TabLayoutMediator
 
-class DNSDetailActivity : AppCompatActivity() {
-    private lateinit var b: ActivityDnsDetailBinding
+class DNSDetailActivity : AppCompatActivity(R.layout.activity_dns_detail) {
+    private val b by viewBinding(ActivityDnsDetailBinding::bind)
     private val DNS_TABS_COUNT = 2
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        b = ActivityDnsDetailBinding.inflate(layoutInflater)
-        setContentView(b.root)
         init()
     }
 

--- a/app/src/main/java/com/celzero/bravedns/ui/DNSLogFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/DNSLogFragment.kt
@@ -51,7 +51,7 @@ import settings.Settings
 import java.net.MalformedURLException
 import java.net.URL
 
-class DNSLogFragment : Fragment(), SearchView.OnQueryTextListener {
+class DNSLogFragment : Fragment(R.layout.activity_query_detail), SearchView.OnQueryTextListener {
     private val b by viewBinding(ActivityQueryDetailBinding::bind)
 
     //private lateinit var context: Context

--- a/app/src/main/java/com/celzero/bravedns/ui/DNSLogFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/DNSLogFragment.kt
@@ -25,11 +25,13 @@ import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.DNSQueryAdapter
 import com.celzero.bravedns.database.DNSLogDAO
 import com.celzero.bravedns.database.DoHEndpoint
 import com.celzero.bravedns.databinding.ActivityQueryDetailBinding
+import com.celzero.bravedns.databinding.FragmentAboutBinding
 import com.celzero.bravedns.service.BraveVPNService
 import com.celzero.bravedns.service.PersistentState
 import com.celzero.bravedns.service.VpnController
@@ -50,8 +52,7 @@ import java.net.MalformedURLException
 import java.net.URL
 
 class DNSLogFragment : Fragment(), SearchView.OnQueryTextListener {
-    private var _binding: ActivityQueryDetailBinding? = null
-    private val b get() = _binding!!
+    private val b by viewBinding(ActivityQueryDetailBinding::bind)
 
     //private lateinit var context: Context
     private var layoutManager: RecyclerView.LayoutManager? = null
@@ -72,16 +73,6 @@ class DNSLogFragment : Fragment(), SearchView.OnQueryTextListener {
 
     private val dnsLogDAO by inject<DNSLogDAO>()
     private val persistentState by inject<PersistentState>()
-
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        super.onCreate(savedInstanceState)
-        _binding = ActivityQueryDetailBinding.inflate(inflater, container, false)
-        //setContentView(R.layout.activity_query_detail)
-        //urlName = resources.getStringArray(R.array.doh_endpoint_names)
-        //urlValues = resources.getStringArray(R.array.doh_endpoint_urls)
-        return b.root
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/celzero/bravedns/ui/FaqWebViewActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/FaqWebViewActivity.kt
@@ -21,19 +21,19 @@ import android.util.Log
 import android.webkit.WebChromeClient
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.databinding.ActivityFaqWebviewLayoutBinding
+import com.celzero.bravedns.databinding.ActivityQueryDetailBinding
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
 import com.celzero.bravedns.util.Constants.Companion.LOG_TAG
 
 
-class FaqWebViewActivity : AppCompatActivity() {
-    private lateinit var b: ActivityFaqWebviewLayoutBinding
+class FaqWebViewActivity : AppCompatActivity(R.layout.activity_faq_webview_layout) {
+    private val b by viewBinding(ActivityFaqWebviewLayoutBinding::bind)
 
     @SuppressLint("SetJavaScriptEnabled") override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        b = ActivityFaqWebviewLayoutBinding.inflate(layoutInflater)
-        setContentView(b.root)
         b.configureWebview.settings.domStorageEnabled = true
         b.configureWebview.settings.allowContentAccess = true
         b.configureWebview.settings.allowFileAccess = true

--- a/app/src/main/java/com/celzero/bravedns/ui/FaqWebViewActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/FaqWebViewActivity.kt
@@ -19,40 +19,39 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.util.Log
 import android.webkit.WebChromeClient
-import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
 import com.celzero.bravedns.R
+import com.celzero.bravedns.databinding.ActivityFaqWebviewLayoutBinding
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
 import com.celzero.bravedns.util.Constants.Companion.LOG_TAG
 
 
-class FaqWebViewActivity  : AppCompatActivity(){
+class FaqWebViewActivity : AppCompatActivity() {
+    private lateinit var b: ActivityFaqWebviewLayoutBinding
 
-    private lateinit var faqWebView : WebView
-
-    @SuppressLint("SetJavaScriptEnabled")
-    override fun onCreate(savedInstanceState: Bundle?) {
+    @SuppressLint("SetJavaScriptEnabled") override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_faq_webview_layout)
-        faqWebView = findViewById(R.id.configure_webview)
-        faqWebView.settings.domStorageEnabled = true
-        faqWebView.settings.allowContentAccess = true
-        faqWebView.settings.allowFileAccess = true
-        faqWebView.settings.javaScriptEnabled = true
-        faqWebView.settings.allowFileAccessFromFileURLs = true
-        faqWebView.settings.allowUniversalAccessFromFileURLs = true
-        faqWebView.settings.setSupportZoom(true)
-        faqWebView.webViewClient = WebViewClient()
-        faqWebView.clearCache(true)
-        faqWebView.clearHistory()
-        faqWebView.isClickable = true
-        faqWebView.webChromeClient = WebChromeClient()
+        b = ActivityFaqWebviewLayoutBinding.inflate(layoutInflater)
+        setContentView(b.root)
+        b.configureWebview.settings.domStorageEnabled = true
+        b.configureWebview.settings.allowContentAccess = true
+        b.configureWebview.settings.allowFileAccess = true
+        b.configureWebview.settings.javaScriptEnabled = true
+        b.configureWebview.settings.allowFileAccessFromFileURLs = true
+        b.configureWebview.settings.allowUniversalAccessFromFileURLs = true
+        b.configureWebview.settings.setSupportZoom(true)
+        b.configureWebview.webViewClient = WebViewClient()
+        b.configureWebview.clearCache(true)
+        b.configureWebview.clearHistory()
+        b.configureWebview.isClickable = true
+        b.configureWebview.webChromeClient = WebChromeClient()
+
         val url = intent.getStringExtra("url")
-        if(url == null) {
-            faqWebView.loadUrl(this.resources.getString(R.string.faq_web_link))
-        }else{
-            faqWebView.loadUrl(url)
+        if (url == null) {
+            b.configureWebview.loadUrl(this.resources.getString(R.string.faq_web_link))
+        } else {
+            b.configureWebview.loadUrl(url)
         }
         /**
          *  faqWebView.evaluateJavascript(
@@ -66,10 +65,9 @@ class FaqWebViewActivity  : AppCompatActivity(){
     }
 
     override fun onDestroy() {
-        if(DEBUG) Log.d(LOG_TAG, "onDestroy")
-        faqWebView.destroy()
+        if (DEBUG) Log.d(LOG_TAG, "onDestroy")
+        b.configureWebview.destroy()
         super.onDestroy()
-
     }
 
 }

--- a/app/src/main/java/com/celzero/bravedns/ui/FilterAndSortBottomFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/FilterAndSortBottomFragment.kt
@@ -20,19 +20,19 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.celzero.bravedns.R
+import com.celzero.bravedns.databinding.FragmentFilterAndSortBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
-class FilterAndSortBottomFragment : BottomSheetDialogFragment(){
-
-
-    private lateinit var fragmentView: View
+class FilterAndSortBottomFragment : BottomSheetDialogFragment() {
+    private var _binding: FragmentFilterAndSortBinding? = null
+    private val b get() = _binding!!
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        fragmentView = inflater.inflate(R.layout.fragment_filter_and_sort, container, false)
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = FragmentFilterAndSortBinding.inflate(inflater, container, false)
         //initView(fragmentView)
-        return fragmentView
+        return b.root
     }
 
     /*override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/celzero/bravedns/ui/FilterAndSortBottomFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/FilterAndSortBottomFragment.kt
@@ -15,23 +15,30 @@ limitations under the License.
 */
 package com.celzero.bravedns.ui
 
-import by.kirich1409.viewbindingdelegate.viewBinding
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import com.celzero.bravedns.R
 import com.celzero.bravedns.databinding.FragmentFilterAndSortBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 class FilterAndSortBottomFragment : BottomSheetDialogFragment() {
-    private val b by viewBinding(FragmentFilterAndSortBinding::bind)
+    private var _binding: FragmentFilterAndSortBinding? = null
+
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val b get() = _binding!!
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
 
-    /*override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        //initView(view)
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = FragmentFilterAndSortBinding.inflate(inflater, container, false)
+        return b.root
     }
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        return super.onCreateDialog(savedInstanceState)
-    }*/
-
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/java/com/celzero/bravedns/ui/FilterAndSortBottomFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/FilterAndSortBottomFragment.kt
@@ -15,25 +15,15 @@ limitations under the License.
 */
 package com.celzero.bravedns.ui
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.databinding.FragmentFilterAndSortBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 class FilterAndSortBottomFragment : BottomSheetDialogFragment() {
-    private var _binding: FragmentFilterAndSortBinding? = null
-    private val b get() = _binding!!
+    private val b by viewBinding(FragmentFilterAndSortBinding::bind)
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = FragmentFilterAndSortBinding.inflate(inflater, container, false)
-        //initView(fragmentView)
-        return b.root
-    }
 
     /*override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/celzero/bravedns/ui/FirewallActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/FirewallActivity.kt
@@ -21,22 +21,21 @@ import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.database.ConnectionTrackerRepository
 import com.celzero.bravedns.databinding.ActivityFirewallBinding
 import com.google.android.material.tabs.TabLayoutMediator
 import org.koin.android.ext.android.inject
 
-class FirewallActivity : AppCompatActivity() {
-    private lateinit var b: ActivityFirewallBinding
+class FirewallActivity : AppCompatActivity(R.layout.activity_faq_webview_layout) {
+    private val b by viewBinding(ActivityFirewallBinding::bind)
     private val FIREWALL_TABS_COUNT = 3
 
     private val connectionTrackerRepository by inject<ConnectionTrackerRepository>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        b = ActivityFirewallBinding.inflate(layoutInflater)
-        setContentView(b.root)
         init()
     }
 

--- a/app/src/main/java/com/celzero/bravedns/ui/FirewallActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/FirewallActivity.kt
@@ -22,31 +22,26 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.celzero.bravedns.R
-import com.celzero.bravedns.database.AppDatabase
 import com.celzero.bravedns.database.ConnectionTrackerRepository
-import com.google.android.material.tabs.TabLayout
+import com.celzero.bravedns.databinding.ActivityFirewallBinding
 import com.google.android.material.tabs.TabLayoutMediator
 import org.koin.android.ext.android.inject
 
 class FirewallActivity : AppCompatActivity() {
-    private lateinit var viewPagerFirewall : ViewPager2
-    private lateinit var tabLayoutFirewall : TabLayout
+    private lateinit var b: ActivityFirewallBinding
     private val FIREWALL_TABS_COUNT = 3
 
     private val connectionTrackerRepository by inject<ConnectionTrackerRepository>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_firewall)
+        b = ActivityFirewallBinding.inflate(layoutInflater)
+        setContentView(b.root)
         init()
     }
 
     private fun init() {
-
-        viewPagerFirewall = findViewById(R.id.firewall_act_viewpager)
-        tabLayoutFirewall = findViewById(R.id.firewall_act_tabLayout)
-
-        viewPagerFirewall.adapter = object : FragmentStateAdapter(this) {
+        b.firewallActViewpager.adapter = object : FragmentStateAdapter(this) {
             override fun createFragment(position: Int): Fragment {
                 return when (position) {
                     0 -> UniversalFirewallFragment.newInstance()
@@ -54,6 +49,7 @@ class FirewallActivity : AppCompatActivity() {
                     else -> FirewallAppFragment.newInstance()
                 }
             }
+
             override fun getItemCount(): Int {
                 return FIREWALL_TABS_COUNT
             }
@@ -61,19 +57,19 @@ class FirewallActivity : AppCompatActivity() {
 
         //viewPagerFirewall.fakeDragBy(1000F)
 
-        TabLayoutMediator(tabLayoutFirewall, viewPagerFirewall) { tab, position ->
+        TabLayoutMediator(b.firewallActTabLayout, b.firewallActViewpager) { tab, position ->
             tab.text = when (position) {
                 0 -> getString(R.string.firewall_act_universal_tab)
                 1 -> getString(R.string.firewall_act_network_monitor_tab)
                 else -> getString(R.string.firewall_act_apps_tab)
             }
-            viewPagerFirewall.setCurrentItem(tab.position, true)
+            b.firewallActViewpager.setCurrentItem(tab.position, true)
         }.attach()
 
 
         val recyclerViewField = ViewPager2::class.java.getDeclaredField("mRecyclerView")
         recyclerViewField.isAccessible = true
-        val recyclerView = recyclerViewField.get(viewPagerFirewall) as RecyclerView
+        val recyclerView = recyclerViewField.get(b.firewallActViewpager) as RecyclerView
 
         val touchSlopField = RecyclerView::class.java.getDeclaredField("mTouchSlop")
         touchSlopField.isAccessible = true

--- a/app/src/main/java/com/celzero/bravedns/ui/FirewallActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/FirewallActivity.kt
@@ -24,11 +24,12 @@ import androidx.viewpager2.widget.ViewPager2
 import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.database.ConnectionTrackerRepository
+import com.celzero.bravedns.databinding.ActivityFaqWebviewLayoutBinding
 import com.celzero.bravedns.databinding.ActivityFirewallBinding
 import com.google.android.material.tabs.TabLayoutMediator
 import org.koin.android.ext.android.inject
 
-class FirewallActivity : AppCompatActivity(R.layout.activity_faq_webview_layout) {
+class FirewallActivity : AppCompatActivity(R.layout.activity_firewall) {
     private val b by viewBinding(ActivityFirewallBinding::bind)
     private val FIREWALL_TABS_COUNT = 3
 

--- a/app/src/main/java/com/celzero/bravedns/ui/FirewallAppFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/FirewallAppFragment.kt
@@ -114,8 +114,8 @@ class FirewallAppFragment : Fragment(R.layout.fragment_firewall_all_apps), Searc
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        observersForUI()
         super.onViewCreated(view, savedInstanceState)
+        observersForUI()
         initView()
         initClickListeners()
     }

--- a/app/src/main/java/com/celzero/bravedns/ui/HomeScreenFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/HomeScreenFragment.kt
@@ -49,11 +49,14 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.SpinnerArrayAdapter
 import com.celzero.bravedns.data.BraveMode
 import com.celzero.bravedns.database.AppInfoRepository
 import com.celzero.bravedns.database.CategoryInfoRepository
+import com.celzero.bravedns.databinding.ActivityHomeScreenBinding
+import com.celzero.bravedns.databinding.FragmentHomeScreenBinding
 import com.celzero.bravedns.service.*
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.appMode
@@ -77,51 +80,8 @@ import java.net.SocketException
 import java.util.*
 
 
-class HomeScreenFragment : Fragment() {
-
-    private lateinit var layoutHeaderView : TextView
-    private lateinit var layoutHeaderViewDesc : TextView
-
-    private lateinit var appManagerLL: LinearLayout
-
-    private lateinit var firewallLL: LinearLayout
-
-    private lateinit var cardViewTileTop : CardView
-
-    private lateinit var tileShowFirewallLL: LinearLayout
-    private lateinit var tileShowDnsLL: LinearLayout
-    private lateinit var tileShowDnsFirewallLL: LinearLayout
-
-    private lateinit var braveModeSpinner: AppCompatSpinner
-    private lateinit var braveModeInfoIcon: ImageView
-
-    private lateinit var dnsOnOffBtn: AppCompatButton
-
-    private lateinit var tileDLifetimeQueriesTxt: TextView
-    private lateinit var tileDmedianTxt: TextView
-    private lateinit var tileDtrackersBlockedTxt: TextView
-
-    private lateinit var tileFAppsBlockedTxt: TextView
-    private lateinit var tileFCategoryBlockedTxt: TextView
-    private lateinit var tileFUniversalBlockedTxt: TextView
-
-    private lateinit var tileDFAppsBlockedTxt: TextView
-    private lateinit var tileDFMedianTxt: TextView
-    private lateinit var tileDFTrackersBlockedtxt: TextView
-
-    private lateinit var appUpTimeTxt: TextView
-
-    private lateinit var chipConfigureFirewall: AppCompatButton
-    private lateinit var chipViewLogs: AppCompatButton
-    private lateinit var btmSheetIcon : Button
-    private lateinit var chipNetworkMonitor : Chip
-    private lateinit var chipSettings : Chip
-
-    private lateinit var protectionDescTxt: TextView
-    private lateinit var protectionLevelTxt: TextView
-
-    private lateinit var shimmerContainer: ShimmerFrameLayout
-    private lateinit var shimmerHeaderContainer : ShimmerFrameLayout
+class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
+    private val b by viewBinding(FragmentHomeScreenBinding::bind)
 
     private val MAIN_CHANNEL_ID = "vpn"
 
@@ -139,9 +99,8 @@ class HomeScreenFragment : Fragment() {
         private const val GREETING_CHANNEL_ID = 2021
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val view: View = inflater.inflate(R.layout.fragment_home_screen, container, false)
-        initView(view)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         syncDnsStatus()
         initializeValues()
         initializeClickListeners()
@@ -153,8 +112,6 @@ class HomeScreenFragment : Fragment() {
         registerForBroadCastReceivers()
 
         checkForHeaderUpdate()
-
-        return view
     }
 
     /**
@@ -182,11 +139,11 @@ class HomeScreenFragment : Fragment() {
         timeToOverride[Calendar.YEAR] = 2021
         if(DEBUG) Log.d(LOG_TAG, "NewYearAlarm : ${currentTime.time}, ${timeToMatch.time}, ${timeToOverride.time} ")
         if(currentTime > timeToMatch && currentTime < timeToOverride ){
-            layoutHeaderView.text = getString(R.string.new_year)
-            layoutHeaderViewDesc.text = getString(R.string.new_year_desc)
+            b.fhsTitleRethink.text = getString(R.string.new_year)
+            b.fhsTitleRethinkDesc.text = getString(R.string.new_year_desc)
         }else{
-            layoutHeaderView.text = getString(R.string.app_name).toLowerCase(Locale.ROOT)
-            layoutHeaderViewDesc.text = getString(R.string.backed_by_mozilla)
+            b.fhsTitleRethink.text = getString(R.string.app_name).toLowerCase(Locale.ROOT)
+            b.fhsTitleRethinkDesc.text = getString(R.string.backed_by_mozilla)
         }
     }
 
@@ -211,14 +168,14 @@ class HomeScreenFragment : Fragment() {
         // Set layout to use when the list of choices appear
         // spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         // Set Adapter to Spinner
-        braveModeSpinner.adapter = spinnerAdapter
+        b.fhsBraveModeSpinner.adapter = spinnerAdapter
 
         braveMode = persistentState.getBraveMode()
 
         if (braveMode == -1) {
-            braveModeSpinner.setSelection(DNS_FIREWALL_MODE)
+            b.fhsBraveModeSpinner.setSelection(DNS_FIREWALL_MODE)
         } else {
-            braveModeSpinner.setSelection(braveMode)
+            b.fhsBraveModeSpinner.setSelection(braveMode)
         }
 
         modifyBraveMode(braveMode)
@@ -230,109 +187,49 @@ class HomeScreenFragment : Fragment() {
         blockedCount.postValue(persistentState.numberOfBlockedRequests)
     }
 
-
-    private fun initView(view: View) {
-
-        layoutHeaderView = view.findViewById(R.id.fhs_title_rethink)
-        layoutHeaderViewDesc = view.findViewById(R.id.fhs_title_rethink_desc)
-
-        //Complete UI component initialization for the view
-        dnsOnOffBtn = view.findViewById(R.id.fhs_dns_on_off_btn)
-
-        /*val detectSwipe = DetectSwipe()
-        dnsOnOffBtn.setOnTouchListener(detectSwipe)*/
-
-        //Shimmer Animation for the heading and start btn
-        shimmerContainer = view.findViewById(R.id.shimmer_view_container1)
-
-       /* shimmerHeaderContainer = view.findViewById(R.id.shimmer_view_heading)
-        //shimmerHeaderContainer.baseAlpha = F
-        shimmerHeaderContainer
-
-        shimmerHeaderContainer.startShimmer()*/
-
-        cardViewTileTop = view.findViewById(R.id.fhs_card_home_top_tile)
-
-        appManagerLL = view.findViewById(R.id.fhs_ll_app_mgr)
-
-        firewallLL = view.findViewById(R.id.fhs_ll_firewall)
-
-        tileShowFirewallLL = view.findViewById(R.id.fhs_tile_show_firewall)
-        tileShowDnsLL = view.findViewById(R.id.fhs_tile_show_dns)
-        tileShowDnsFirewallLL = view.findViewById(R.id.fhs_tile_show_dns_firewall)
-
-        tileDLifetimeQueriesTxt = view.findViewById(R.id.fhs_tile_dns_lifetime_txt)
-        tileDmedianTxt = view.findViewById(R.id.fhs_tile_dns_median_latency_txt)
-        tileDtrackersBlockedTxt = view.findViewById(R.id.fhs_tile_dns_trackers_blocked_txt)
-
-        tileFAppsBlockedTxt = view.findViewById(R.id.fhs_tile_firewall_apps_txt)
-        tileFCategoryBlockedTxt = view.findViewById(R.id.fhs_tile_firewall_category_txt)
-        tileFUniversalBlockedTxt = view.findViewById(R.id.fhs_tile_firewall_universal_txt)
-
-        tileDFAppsBlockedTxt = view.findViewById(R.id.fhs_tile_dns_firewall_apps_blocked_txt)
-        tileDFMedianTxt = view.findViewById(R.id.fhs_tile_dns_firewall_median_latency_txt)
-        tileDFTrackersBlockedtxt = view.findViewById(R.id.fhs_tile_dns_firewall_trackers_blocked_txt)
-
-        appUpTimeTxt = view.findViewById(R.id.fhs_app_uptime)
-
-        protectionLevelTxt = view.findViewById(R.id.fhs_protection_level_txt)
-        protectionDescTxt = view.findViewById(R.id.fhs_app_connected_desc)
-
-        //Spinner Adapter code
-        braveModeSpinner = view.findViewById(R.id.fhs_brave_mode_spinner)
-        braveModeInfoIcon = view.findViewById(R.id.fhs_dns_mode_info)
-        //For Chip
-        chipConfigureFirewall = view.findViewById(R.id.chip_configure_firewall)
-        chipViewLogs = view.findViewById(R.id.chip_view_logs)
-        chipSettings = view.findViewById(R.id.chip_settings)
-        chipNetworkMonitor = view.findViewById(R.id.chip_network_monitor)
-
-        btmSheetIcon = view.findViewById(R.id.home_fragment_bottom_sheet_icon)
-    }
-
     private fun initializeClickListeners() {
     // BraveMode Spinner OnClick
-        braveModeSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+        b.fhsBraveModeSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(parent: AdapterView<*>?) {
                 braveMode = DNS_FIREWALL_MODE
             }
             override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
-                braveModeSpinner.isEnabled = false
+                b.fhsBraveModeSpinner.isEnabled = false
                 modifyBraveMode(position)
                 showTileForMode()
                 object : CountDownTimer(1000, 500) {
                     override fun onTick(millisUntilFinished: Long) {
-                        braveModeSpinner.isEnabled = false
+                        b.fhsBraveModeSpinner.isEnabled = false
                     }
                     override fun onFinish() {
-                        braveModeSpinner.isEnabled = true
+                        b.fhsBraveModeSpinner.isEnabled = true
                     }
                 }.start()
             }
         }
 
         // Brave Mode Information Icon which shows the dialog - explanation
-        braveModeInfoIcon.setOnClickListener {
+        b.fhsDnsModeInfo.setOnClickListener {
             showDialogForBraveModeInfo()
         }
 
         //Chips for the Configure Firewall
-        chipConfigureFirewall.setOnClickListener {
+        b.chipConfigureFirewall.setOnClickListener {
             if(DEBUG) Log.d(LOG_TAG, "Status : Configure firewall clicked")
             startFirewallActivity()
         }
 
         //Chips for the DNS Screen
-        chipViewLogs.setOnClickListener {
+        b.chipViewLogs.setOnClickListener {
             //startQueryListener()
             startConnectionTrackerActivity()
         }
 
-        chipNetworkMonitor.setOnClickListener{
+        b.chipNetworkMonitor.setOnClickListener{
             //startBottomSheetForSettings()
         }
 
-        chipSettings.setOnClickListener{
+        b.chipSettings.setOnClickListener{
             /*val threadPoolExecutor = ThreadPoolExecutor(
                 2, 2, 0,
                 TimeUnit.MILLISECONDS, LinkedBlockingQueue<Runnable>()
@@ -345,26 +242,26 @@ class HomeScreenFragment : Fragment() {
             }*/
         }
 
-        btmSheetIcon.setOnClickListener{
-            btmSheetIcon.isEnabled = false
+        b.homeFragmentBottomSheetIcon.setOnClickListener{
+            b.homeFragmentBottomSheetIcon.isEnabled = false
             openBottomSheet()
-            Handler().postDelayed({ btmSheetIcon.isEnabled = true }, 500)
+            Handler().postDelayed({  b.homeFragmentBottomSheetIcon.isEnabled = true }, 500)
             //startBottomSheetForSettings()
         }
 
         // Connect/Disconnect button ==> TODO : Change the label to Start and Stop
-        dnsOnOffBtn.setOnClickListener {
+        b.fhsDnsOnOffBtn.setOnClickListener {
             handleStartBtnClickEvent()
         }
 
         categoryInfoRepository.getAppCategoryForLiveData().observe(viewLifecycleOwner, {
             val list = it.filter { a -> a.isInternetBlocked }
-            tileFCategoryBlockedTxt.text = list.size.toString()
+            b.fhsTileFirewallCategoryTxt.text = list.size.toString()
         })
 
         median50.observe(viewLifecycleOwner, {
-            tileDmedianTxt.text = median50.value.toString() + "ms"
-            tileDFMedianTxt.text = median50.value.toString() + "ms"
+            b.fhsTileDnsMedianLatencyTxt.text = median50.value.toString() + "ms"
+            b.fhsTileDnsFirewallMedianLatencyTxt.text = median50.value.toString() + "ms"
         })
 
         lifeTimeQ.observe(viewLifecycleOwner, {
@@ -374,7 +271,7 @@ class HomeScreenFragment : Fragment() {
                 // FIXME: 19-11-2020 - Format the number similar to CompctDecimalFormat
                 lifeTimeQ.value.toString()
             }
-            tileDLifetimeQueriesTxt.text = lifeTimeConversion
+            b.fhsTileDnsLifetimeTxt.text = lifeTimeConversion
         })
 
          blockedCount.observe(viewLifecycleOwner, {
@@ -384,17 +281,17 @@ class HomeScreenFragment : Fragment() {
                  // FIXME: 19-11-2020 - Format the number similar to CompctDecimalFormat
                  blockedCount.value.toString()
              }
-             tileDFTrackersBlockedtxt.text = blocked
-             tileDtrackersBlockedTxt.text = blocked
+             b.fhsTileDnsFirewallTrackersBlockedTxt.text = blocked
+             b.fhsTileDnsTrackersBlockedTxt.text = blocked
          })
 
         appInfoRepository.getBlockedAppCount().observe(viewLifecycleOwner, {
-            tileFAppsBlockedTxt.text = it.toString()
-            tileDFAppsBlockedTxt.text = it.toString()
+            b.fhsTileFirewallAppsTxt.text = it.toString()
+            b.fhsTileDnsFirewallAppsBlockedTxt.text = it.toString()
         })
 
         numUniversalBlock.observe(viewLifecycleOwner, {
-            tileFUniversalBlockedTxt.text = numUniversalBlock.value.toString()
+            b.fhsTileFirewallUniversalTxt.text = numUniversalBlock.value.toString()
         })
 
         braveModeToggler.observe(viewLifecycleOwner, {
@@ -407,7 +304,7 @@ class HomeScreenFragment : Fragment() {
     }
 
     private fun handleStartBtnClickEvent() {
-        dnsOnOffBtn.isEnabled = false
+        b.fhsDnsOnOffBtn.isEnabled = false
         //TODO : check for the service already running
         //val status = VpnController.getInstance()!!.getState(requireContext())
         val status = persistentState.vpnEnabled
@@ -415,10 +312,10 @@ class HomeScreenFragment : Fragment() {
             //if (status!!.activationRequested) {
             if (status) {
                 appStartTime = System.currentTimeMillis()
-                dnsOnOffBtn.setText("start")
+                b.fhsDnsOnOffBtn.setText("start")
                 updateUIForStop()
                 //rippleRRLayout.startRippleAnimation()
-                protectionDescTxt.setText(getString(R.string.dns_explanation_disconnected))
+                b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_disconnected))
                 stopDnsVpnService()
             } else {
                 appStartTime = System.currentTimeMillis()
@@ -434,11 +331,11 @@ class HomeScreenFragment : Fragment() {
         } else if (status) {
             Utilities.showToastInMidLayout(requireContext(), getString(R.string.always_on_rethink_enabled), Toast.LENGTH_SHORT)
         }
-        Handler().postDelayed({ dnsOnOffBtn.isEnabled = true }, 500)
+        Handler().postDelayed({ b.fhsDnsOnOffBtn.isEnabled = true }, 500)
     }
 
     private fun openBottomSheet() {
-        val textConnectionDetails = protectionDescTxt.text.toString()
+        val textConnectionDetails = b.fhsAppConnectedDesc.text.toString()
         val bottomSheetFragment = HomeScreenSettingBottomSheet(textConnectionDetails)
         val frag = context as FragmentActivity
         bottomSheetFragment.show(frag.supportFragmentManager, bottomSheetFragment.tag)
@@ -516,19 +413,19 @@ class HomeScreenFragment : Fragment() {
 
     private fun showTileForMode() {
         if (braveMode == DNS_MODE) {
-            tileShowDnsLL.visibility = View.VISIBLE
-            tileShowFirewallLL.visibility = View.GONE
-            tileShowDnsFirewallLL.visibility = View.GONE
+            b.fhsTileShowDns.visibility = View.VISIBLE
+            b.fhsTileShowFirewall.visibility = View.GONE
+            b.fhsTileShowDnsFirewall.visibility = View.GONE
         } else if (braveMode == FIREWALL_MODE) {
-            tileShowDnsLL.visibility = View.GONE
-            tileShowFirewallLL.visibility = View.VISIBLE
-            tileShowDnsFirewallLL.visibility = View.GONE
+            b.fhsTileShowDns.visibility = View.GONE
+            b.fhsTileShowFirewall.visibility = View.VISIBLE
+            b.fhsTileShowDnsFirewall.visibility = View.GONE
         } else if (braveMode == DNS_FIREWALL_MODE) {
-            tileShowDnsLL.visibility = View.GONE
-            tileShowFirewallLL.visibility = View.GONE
-            tileShowDnsFirewallLL.visibility = View.VISIBLE
+            b.fhsTileShowDns.visibility = View.GONE
+            b.fhsTileShowFirewall.visibility = View.GONE
+            b.fhsTileShowDnsFirewall.visibility = View.VISIBLE
         }
-        braveModeSpinner.isEnabled = true
+        b.fhsBraveModeSpinner.isEnabled = true
     }
 
     //https://stackoverflow.com/questions/2614545/animate-change-of-view-background-color-on-android/14467625#14467625
@@ -537,40 +434,40 @@ class HomeScreenFragment : Fragment() {
         val fadeIn: Animation = AnimationUtils.loadAnimation(requireContext(), R.anim.fade_in)
 
         if (braveMode == DNS_MODE) {
-            chipViewLogs.startAnimation(fadeOut)
-            chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_primary)
-            chipViewLogs.startAnimation(fadeIn)
-            chipConfigureFirewall.startAnimation(fadeOut)
-            chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_accent)
-            chipConfigureFirewall.startAnimation(fadeIn)
+            b.chipViewLogs.startAnimation(fadeOut)
+            b.chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_primary)
+            b.chipViewLogs.startAnimation(fadeIn)
+            b.chipConfigureFirewall.startAnimation(fadeOut)
+            b.chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_accent)
+            b.chipConfigureFirewall.startAnimation(fadeIn)
         } else if (braveMode == FIREWALL_MODE) {
-            chipViewLogs.startAnimation(fadeOut)
-            chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_accent)
-            chipViewLogs.startAnimation(fadeIn)
-            chipConfigureFirewall.startAnimation(fadeOut)
-            chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_primary)
-            chipConfigureFirewall.startAnimation(fadeIn)
+            b.chipViewLogs.startAnimation(fadeOut)
+            b.chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_accent)
+            b.chipViewLogs.startAnimation(fadeIn)
+            b.chipConfigureFirewall.startAnimation(fadeOut)
+            b.chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_primary)
+            b.chipConfigureFirewall.startAnimation(fadeIn)
         } else if (braveMode == DNS_FIREWALL_MODE) {
-            chipViewLogs.startAnimation(fadeOut)
-            chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_primary)
-            chipViewLogs.startAnimation(fadeIn)
+            b.chipViewLogs.startAnimation(fadeOut)
+            b.chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_primary)
+            b.chipViewLogs.startAnimation(fadeIn)
 
-            chipConfigureFirewall.startAnimation(fadeOut)
-            chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_primary)
-            chipConfigureFirewall.startAnimation(fadeIn)
+            b.chipConfigureFirewall.startAnimation(fadeOut)
+            b.chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_primary)
+            b.chipConfigureFirewall.startAnimation(fadeIn)
         }
     }
 
     private fun disableBraveModeIcon() {
         val fadeOut: Animation = AnimationUtils.loadAnimation(requireContext(), R.anim.fade_out)
         val fadeIn: Animation = AnimationUtils.loadAnimation(requireContext(), R.anim.fade_in)
-        chipViewLogs.startAnimation(fadeOut)
-        chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_accent)
-        chipViewLogs.startAnimation(fadeIn)
+        b.chipViewLogs.startAnimation(fadeOut)
+        b.chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_accent)
+        b.chipViewLogs.startAnimation(fadeIn)
 
-        chipConfigureFirewall.startAnimation(fadeOut)
-        chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_accent)
-        chipConfigureFirewall.startAnimation(fadeIn)
+        b.chipConfigureFirewall.startAnimation(fadeOut)
+        b.chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_accent)
+        b.chipConfigureFirewall.startAnimation(fadeIn)
     }
 
 
@@ -640,15 +537,15 @@ class HomeScreenFragment : Fragment() {
 
         if (VpnController.getInstance()!!.getState(requireContext())!!.activationRequested) {
             if (braveMode == 0){
-                protectionDescTxt.setText(getString(R.string.dns_explanation_dns_connected))
+                b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_dns_connected))
             }else if (braveMode == 1) {
-                protectionDescTxt.setText(getString(R.string.dns_explanation_firewall_connected))
+                b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_firewall_connected))
             } else {
-                protectionDescTxt.setText(getString(R.string.dns_explanation_connected))
+                b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_connected))
             }
         }
 
-        braveModeSpinner.isEnabled = true
+        b.fhsBraveModeSpinner.isEnabled = true
     }
 
     /**
@@ -703,14 +600,14 @@ class HomeScreenFragment : Fragment() {
 
     private fun updateUptime() {
         val upTime = DateUtils.getRelativeTimeSpanString(appStartTime, System.currentTimeMillis(), MINUTE_IN_MILLIS, FORMAT_ABBREV_RELATIVE)
-        appUpTimeTxt.setText("($upTime)")
+        b.fhsAppUptime.setText("($upTime)")
     }
 
     private fun prepareAndStartDnsVpn() {
         if (hasVpnService()) {
             if (prepareVpnService()) {
-                dnsOnOffBtn.setText("stop")
-                dnsOnOffBtn.setBackgroundResource(R.drawable.rounded_corners_button_accent)
+                b.fhsDnsOnOffBtn.setText("stop")
+                b.fhsDnsOnOffBtn.setBackgroundResource(R.drawable.rounded_corners_button_accent)
                 updateUIForStart()
                 startDnsVpnService()
                 if(DEBUG) Log.d(LOG_TAG, "VPN service start initiated - startDnsVpnService()")
@@ -731,7 +628,7 @@ class HomeScreenFragment : Fragment() {
         builder.setBaseAlpha(0.85f)
         builder.setDropoff(1f)
         builder.setHighlightAlpha(0.35f)
-        shimmerContainer.setShimmer(builder.build())
+        b.shimmerViewContainer1.setShimmer(builder.build())
     }
 
     private fun shimmerForStop(){
@@ -740,7 +637,7 @@ class HomeScreenFragment : Fragment() {
         builder.setBaseAlpha(0.85f)
         builder.setDropoff(1f)
         builder.setHighlightAlpha(0.35f)
-        shimmerContainer.setShimmer(builder.build())
+        b.shimmerViewContainer1.setShimmer(builder.build())
     }
 
     private fun updateUIForStop(){
@@ -755,11 +652,11 @@ class HomeScreenFragment : Fragment() {
     private fun startDnsVpnService() {
         VpnController.getInstance()?.start(requireContext())
         if (braveMode == 0) {
-            protectionDescTxt.setText(getString(R.string.dns_explanation_dns_connected))
+            b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_dns_connected))
         } else if (braveMode == 1) {
-            protectionDescTxt.setText(getString(R.string.dns_explanation_firewall_connected))
+            b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_firewall_connected))
         } else {
-            protectionDescTxt.setText(getString(R.string.dns_explanation_connected))
+            b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_connected))
         }
     }
 
@@ -803,19 +700,19 @@ class HomeScreenFragment : Fragment() {
         val status = VpnController.getInstance()!!.getState(requireContext())
 
         if (status!!.activationRequested || status.connectionState == BraveVPNService.State.WORKING) {
-            dnsOnOffBtn.setBackgroundResource(R.drawable.rounded_corners_button_accent)
-            dnsOnOffBtn.text = "stop"
+            b.fhsDnsOnOffBtn.setBackgroundResource(R.drawable.rounded_corners_button_accent)
+            b.fhsDnsOnOffBtn.text = "stop"
             if (braveMode == 0)
-                protectionDescTxt.text = getString(R.string.dns_explanation_dns_connected)
+                b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_dns_connected)
             else if (braveMode == 1)
-                protectionDescTxt.text = getString(R.string.dns_explanation_firewall_connected)
+                b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_firewall_connected)
             else
-                protectionDescTxt.text = getString(R.string.dns_explanation_connected)
+                b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_connected)
         } else {
-            dnsOnOffBtn.setBackgroundResource(R.drawable.rounded_corners_button_primary)
+            b.fhsDnsOnOffBtn.setBackgroundResource(R.drawable.rounded_corners_button_primary)
             updateUIForStop()
-            dnsOnOffBtn.text = "start"
-            protectionDescTxt.text = getString(R.string.dns_explanation_disconnected)
+            b.fhsDnsOnOffBtn.text = "start"
+            b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_disconnected)
         }
 
         // Change status and explanation text
@@ -880,8 +777,8 @@ class HomeScreenFragment : Fragment() {
             colorId = R.color.positive
 
         val color = ContextCompat.getColor(requireContext(), colorId)
-        protectionLevelTxt.setTextColor(color)
-        protectionLevelTxt.setText(statusId)
+        b.fhsProtectionLevelTxt.setTextColor(color)
+        b.fhsProtectionLevelTxt.setText(statusId)
 
     }
 

--- a/app/src/main/java/com/celzero/bravedns/ui/HomeScreenFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/HomeScreenFragment.kt
@@ -34,17 +34,14 @@ import android.text.format.DateUtils
 import android.text.format.DateUtils.FORMAT_ABBREV_RELATIVE
 import android.text.format.DateUtils.MINUTE_IN_MILLIS
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.Window
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
-import android.widget.*
+import android.widget.AdapterView
+import android.widget.ImageView
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.widget.AppCompatButton
-import androidx.appcompat.widget.AppCompatSpinner
-import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -55,7 +52,6 @@ import com.celzero.bravedns.adapter.SpinnerArrayAdapter
 import com.celzero.bravedns.data.BraveMode
 import com.celzero.bravedns.database.AppInfoRepository
 import com.celzero.bravedns.database.CategoryInfoRepository
-import com.celzero.bravedns.databinding.ActivityHomeScreenBinding
 import com.celzero.bravedns.databinding.FragmentHomeScreenBinding
 import com.celzero.bravedns.service.*
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
@@ -71,8 +67,6 @@ import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.numUniversalBlo
 import com.celzero.bravedns.util.Constants.Companion.LOG_TAG
 import com.celzero.bravedns.util.Utilities
 import com.facebook.shimmer.Shimmer
-import com.facebook.shimmer.ShimmerFrameLayout
-import com.google.android.material.chip.Chip
 import org.koin.android.ext.android.inject
 import settings.Settings
 import java.net.NetworkInterface
@@ -115,9 +109,9 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
     }
 
     /**
-    *   Function to show the new year wishes to the user,
-    *   As of now the function will check for new year time and
-    *   will turn the text heading and description.
+     *   Function to show the new year wishes to the user,
+     *   As of now the function will check for new year time and
+     *   will turn the text heading and description.
      */
     private fun checkForHeaderUpdate() {
         val currentTime = Calendar.getInstance(Locale.ROOT)
@@ -137,11 +131,11 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         timeToOverride[Calendar.DAY_OF_MONTH] = 1
         timeToOverride[Calendar.MONTH] = 0
         timeToOverride[Calendar.YEAR] = 2021
-        if(DEBUG) Log.d(LOG_TAG, "NewYearAlarm : ${currentTime.time}, ${timeToMatch.time}, ${timeToOverride.time} ")
-        if(currentTime > timeToMatch && currentTime < timeToOverride ){
+        if (DEBUG) Log.d(LOG_TAG, "NewYearAlarm : ${currentTime.time}, ${timeToMatch.time}, ${timeToOverride.time} ")
+        if (currentTime > timeToMatch && currentTime < timeToOverride) {
             b.fhsTitleRethink.text = getString(R.string.new_year)
             b.fhsTitleRethinkDesc.text = getString(R.string.new_year_desc)
-        }else{
+        } else {
             b.fhsTitleRethink.text = getString(R.string.app_name).toLowerCase(Locale.ROOT)
             b.fhsTitleRethinkDesc.text = getString(R.string.backed_by_mozilla)
         }
@@ -188,11 +182,12 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
     }
 
     private fun initializeClickListeners() {
-    // BraveMode Spinner OnClick
+        // BraveMode Spinner OnClick
         b.fhsBraveModeSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onNothingSelected(parent: AdapterView<*>?) {
                 braveMode = DNS_FIREWALL_MODE
             }
+
             override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
                 b.fhsBraveModeSpinner.isEnabled = false
                 modifyBraveMode(position)
@@ -201,6 +196,7 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
                     override fun onTick(millisUntilFinished: Long) {
                         b.fhsBraveModeSpinner.isEnabled = false
                     }
+
                     override fun onFinish() {
                         b.fhsBraveModeSpinner.isEnabled = true
                     }
@@ -215,7 +211,7 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
 
         //Chips for the Configure Firewall
         b.chipConfigureFirewall.setOnClickListener {
-            if(DEBUG) Log.d(LOG_TAG, "Status : Configure firewall clicked")
+            if (DEBUG) Log.d(LOG_TAG, "Status : Configure firewall clicked")
             startFirewallActivity()
         }
 
@@ -225,11 +221,11 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
             startConnectionTrackerActivity()
         }
 
-        b.chipNetworkMonitor.setOnClickListener{
+        b.chipNetworkMonitor.setOnClickListener {
             //startBottomSheetForSettings()
         }
 
-        b.chipSettings.setOnClickListener{
+        b.chipSettings.setOnClickListener {
             /*val threadPoolExecutor = ThreadPoolExecutor(
                 2, 2, 0,
                 TimeUnit.MILLISECONDS, LinkedBlockingQueue<Runnable>()
@@ -242,10 +238,10 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
             }*/
         }
 
-        b.homeFragmentBottomSheetIcon.setOnClickListener{
+        b.homeFragmentBottomSheetIcon.setOnClickListener {
             b.homeFragmentBottomSheetIcon.isEnabled = false
             openBottomSheet()
-            Handler().postDelayed({  b.homeFragmentBottomSheetIcon.isEnabled = true }, 500)
+            Handler().postDelayed({ b.homeFragmentBottomSheetIcon.isEnabled = true }, 500)
             //startBottomSheetForSettings()
         }
 
@@ -274,16 +270,16 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
             b.fhsTileDnsLifetimeTxt.text = lifeTimeConversion
         })
 
-         blockedCount.observe(viewLifecycleOwner, {
-             val blocked = if (VERSION.SDK_INT >= VERSION_CODES.N) {
-                 CompactDecimalFormat.getInstance(Locale.US, CompactDecimalFormat.CompactStyle.SHORT).format(blockedCount.value)
-             } else {
-                 // FIXME: 19-11-2020 - Format the number similar to CompctDecimalFormat
-                 blockedCount.value.toString()
-             }
-             b.fhsTileDnsFirewallTrackersBlockedTxt.text = blocked
-             b.fhsTileDnsTrackersBlockedTxt.text = blocked
-         })
+        blockedCount.observe(viewLifecycleOwner, {
+            val blocked = if (VERSION.SDK_INT >= VERSION_CODES.N) {
+                CompactDecimalFormat.getInstance(Locale.US, CompactDecimalFormat.CompactStyle.SHORT).format(blockedCount.value)
+            } else {
+                // FIXME: 19-11-2020 - Format the number similar to CompctDecimalFormat
+                blockedCount.value.toString()
+            }
+            b.fhsTileDnsFirewallTrackersBlockedTxt.text = blocked
+            b.fhsTileDnsTrackersBlockedTxt.text = blocked
+        })
 
         appInfoRepository.getBlockedAppCount().observe(viewLifecycleOwner, {
             b.fhsTileFirewallAppsTxt.text = it.toString()
@@ -312,10 +308,10 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
             //if (status!!.activationRequested) {
             if (status) {
                 appStartTime = System.currentTimeMillis()
-                b.fhsDnsOnOffBtn.setText("start")
+                b.fhsDnsOnOffBtn.text = "start"
                 updateUIForStop()
                 //rippleRRLayout.startRippleAnimation()
-                b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_disconnected))
+                b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_disconnected)
                 stopDnsVpnService()
             } else {
                 appStartTime = System.currentTimeMillis()
@@ -349,7 +345,7 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
     }
 
     // FIXME: 19-11-2020 - Check the below code for all the edge cases.
-    private fun checkForPrivateDNSandAlwaysON() : Boolean {
+    private fun checkForPrivateDNSandAlwaysON(): Boolean {
         val stats = persistentState.vpnEnabled
         val alwaysOn = android.provider.Settings.Secure.getString(context?.contentResolver, "always_on_vpn_app")
         if (!TextUtils.isEmpty(alwaysOn)) {
@@ -369,21 +365,21 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
     }
 
     private fun startConnectionTrackerActivity() {
-            val status: VpnState? = VpnController.getInstance()!!.getState(context)
-            if((status?.on!!) ) {
-                if(braveMode == DNS_FIREWALL_MODE || braveMode == DNS_MODE && (getPrivateDnsMode() != PrivateDnsMode.STRICT)) {
-                    val intent = Intent(requireContext(), DNSDetailActivity::class.java)
-                    startActivity(intent)
-                }else{
-                    if(getPrivateDnsMode() == PrivateDnsMode.STRICT){
-                        Utilities.showToastInMidLayout(requireContext(), resources.getText(R.string.private_dns_toast).toString().capitalize(Locale.ROOT), Toast.LENGTH_SHORT)
-                    }
-                    Utilities.showToastInMidLayout(requireContext(), resources.getText(R.string.brave_dns_connect_mode_change_dns).toString().capitalize(Locale.ROOT), Toast.LENGTH_SHORT)
+        val status: VpnState? = VpnController.getInstance()!!.getState(context)
+        if ((status?.on!!)) {
+            if (braveMode == DNS_FIREWALL_MODE || braveMode == DNS_MODE && (getPrivateDnsMode() != PrivateDnsMode.STRICT)) {
+                val intent = Intent(requireContext(), DNSDetailActivity::class.java)
+                startActivity(intent)
+            } else {
+                if (getPrivateDnsMode() == PrivateDnsMode.STRICT) {
+                    Utilities.showToastInMidLayout(requireContext(), resources.getText(R.string.private_dns_toast).toString().capitalize(Locale.ROOT), Toast.LENGTH_SHORT)
                 }
-            }else{
                 Utilities.showToastInMidLayout(requireContext(), resources.getText(R.string.brave_dns_connect_mode_change_dns).toString().capitalize(Locale.ROOT), Toast.LENGTH_SHORT)
             }
+        } else {
+            Utilities.showToastInMidLayout(requireContext(), resources.getText(R.string.brave_dns_connect_mode_change_dns).toString().capitalize(Locale.ROOT), Toast.LENGTH_SHORT)
         }
+    }
 
     private fun showDialogForAlwaysOn() {
         val builder = AlertDialog.Builder(requireContext())
@@ -393,13 +389,13 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         builder.setMessage(R.string.always_on_dialog)
         builder.setCancelable(true)
         //performing positive action
-        builder.setPositiveButton(R.string.always_on_dialog_positive_btn) { dialogInterface, which ->
+        builder.setPositiveButton(R.string.always_on_dialog_positive_btn) { _, _ ->
             val intent = Intent("android.net.vpn.SETTINGS")
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             startActivity(intent)
         }
 
-        builder.setNegativeButton(R.string.always_on_dialog_negative_btn) { dialogInterface, which ->
+        builder.setNegativeButton(R.string.always_on_dialog_negative_btn) { _, _ ->
         }
 
         // Create the AlertDialog
@@ -412,18 +408,22 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
 
 
     private fun showTileForMode() {
-        if (braveMode == DNS_MODE) {
-            b.fhsTileShowDns.visibility = View.VISIBLE
-            b.fhsTileShowFirewall.visibility = View.GONE
-            b.fhsTileShowDnsFirewall.visibility = View.GONE
-        } else if (braveMode == FIREWALL_MODE) {
-            b.fhsTileShowDns.visibility = View.GONE
-            b.fhsTileShowFirewall.visibility = View.VISIBLE
-            b.fhsTileShowDnsFirewall.visibility = View.GONE
-        } else if (braveMode == DNS_FIREWALL_MODE) {
-            b.fhsTileShowDns.visibility = View.GONE
-            b.fhsTileShowFirewall.visibility = View.GONE
-            b.fhsTileShowDnsFirewall.visibility = View.VISIBLE
+        when (braveMode) {
+            DNS_MODE -> {
+                b.fhsTileShowDns.visibility = View.VISIBLE
+                b.fhsTileShowFirewall.visibility = View.GONE
+                b.fhsTileShowDnsFirewall.visibility = View.GONE
+            }
+            FIREWALL_MODE -> {
+                b.fhsTileShowDns.visibility = View.GONE
+                b.fhsTileShowFirewall.visibility = View.VISIBLE
+                b.fhsTileShowDnsFirewall.visibility = View.GONE
+            }
+            DNS_FIREWALL_MODE -> {
+                b.fhsTileShowDns.visibility = View.GONE
+                b.fhsTileShowFirewall.visibility = View.GONE
+                b.fhsTileShowDnsFirewall.visibility = View.VISIBLE
+            }
         }
         b.fhsBraveModeSpinner.isEnabled = true
     }
@@ -433,28 +433,32 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         val fadeOut: Animation = AnimationUtils.loadAnimation(requireContext(), R.anim.fade_out)
         val fadeIn: Animation = AnimationUtils.loadAnimation(requireContext(), R.anim.fade_in)
 
-        if (braveMode == DNS_MODE) {
-            b.chipViewLogs.startAnimation(fadeOut)
-            b.chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_primary)
-            b.chipViewLogs.startAnimation(fadeIn)
-            b.chipConfigureFirewall.startAnimation(fadeOut)
-            b.chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_accent)
-            b.chipConfigureFirewall.startAnimation(fadeIn)
-        } else if (braveMode == FIREWALL_MODE) {
-            b.chipViewLogs.startAnimation(fadeOut)
-            b.chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_accent)
-            b.chipViewLogs.startAnimation(fadeIn)
-            b.chipConfigureFirewall.startAnimation(fadeOut)
-            b.chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_primary)
-            b.chipConfigureFirewall.startAnimation(fadeIn)
-        } else if (braveMode == DNS_FIREWALL_MODE) {
-            b.chipViewLogs.startAnimation(fadeOut)
-            b.chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_primary)
-            b.chipViewLogs.startAnimation(fadeIn)
+        when (braveMode) {
+            DNS_MODE -> {
+                b.chipViewLogs.startAnimation(fadeOut)
+                b.chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_primary)
+                b.chipViewLogs.startAnimation(fadeIn)
+                b.chipConfigureFirewall.startAnimation(fadeOut)
+                b.chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_accent)
+                b.chipConfigureFirewall.startAnimation(fadeIn)
+            }
+            FIREWALL_MODE -> {
+                b.chipViewLogs.startAnimation(fadeOut)
+                b.chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_accent)
+                b.chipViewLogs.startAnimation(fadeIn)
+                b.chipConfigureFirewall.startAnimation(fadeOut)
+                b.chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_primary)
+                b.chipConfigureFirewall.startAnimation(fadeIn)
+            }
+            DNS_FIREWALL_MODE -> {
+                b.chipViewLogs.startAnimation(fadeOut)
+                b.chipViewLogs.setBackgroundResource(R.drawable.rounded_corners_button_primary)
+                b.chipViewLogs.startAnimation(fadeIn)
 
-            b.chipConfigureFirewall.startAnimation(fadeOut)
-            b.chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_primary)
-            b.chipConfigureFirewall.startAnimation(fadeIn)
+                b.chipConfigureFirewall.startAnimation(fadeOut)
+                b.chipConfigureFirewall.setBackgroundResource(R.drawable.rounded_corners_button_primary)
+                b.chipConfigureFirewall.startAnimation(fadeIn)
+            }
         }
     }
 
@@ -478,12 +482,10 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         if (persistentState.vpnEnabled) {
             enableBraveModeIcons()
             shimmerForStart()
-        }else{
+        } else {
             shimmerForStop()
         }
     }
-
-
 
 
     /**
@@ -491,16 +493,16 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
      */
     private fun startFirewallActivity() {
         val status: VpnState? = VpnController.getInstance()!!.getState(requireContext())
-        if(DEBUG) Log.d(LOG_TAG, "Status : ${status?.on!!} , BraveMode: $braveMode")
-         if(status?.on!!){
+        if (DEBUG) Log.d(LOG_TAG, "Status : ${status?.on!!} , BraveMode: $braveMode")
+        if (status?.on!!) {
             if (braveMode == DNS_FIREWALL_MODE || braveMode == FIREWALL_MODE) {
                 val intent = Intent(requireContext(), FirewallActivity::class.java)
                 startActivity(intent)
             } else {
                 Utilities.showToastInMidLayout(requireContext(), resources.getText(R.string.brave_dns_connect_mode_change_firewall).toString().capitalize(Locale.ROOT), Toast.LENGTH_SHORT)
             }
-        }else {
-             Utilities.showToastInMidLayout(requireContext(), resources.getText(R.string.brave_dns_connect_mode_change_firewall).toString().capitalize(Locale.ROOT), Toast.LENGTH_SHORT)
+        } else {
+            Utilities.showToastInMidLayout(requireContext(), resources.getText(R.string.brave_dns_connect_mode_change_firewall).toString().capitalize(Locale.ROOT), Toast.LENGTH_SHORT)
         }
     }
 
@@ -511,24 +513,20 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
             firewallMode = Settings.BlockModeNone
             braveMode = DNS_MODE
         } else if (position == 1) {
-            firewallMode = if (VERSION.SDK_INT >= VERSION_CODES.M && VERSION.SDK_INT < VERSION_CODES.Q)
-                Settings.BlockModeFilterProc
-            else
-                Settings.BlockModeFilter
+            firewallMode = if (VERSION.SDK_INT >= VERSION_CODES.M && VERSION.SDK_INT < VERSION_CODES.Q) Settings.BlockModeFilterProc
+            else Settings.BlockModeFilter
             braveMode = FIREWALL_MODE
         } else if (position == 2) {
-            firewallMode = if(VERSION.SDK_INT >= VERSION_CODES.M && VERSION.SDK_INT < VERSION_CODES.Q)
-                Settings.BlockModeFilterProc
-            else
-                Settings.BlockModeFilter
+            firewallMode = if (VERSION.SDK_INT >= VERSION_CODES.M && VERSION.SDK_INT < VERSION_CODES.Q) Settings.BlockModeFilterProc
+            else Settings.BlockModeFilter
             braveMode = DNS_FIREWALL_MODE
         }
-        if(DEBUG) Log.d(LOG_TAG, "Firewall mode : $firewallMode, braveMode: $braveMode, SDK_Version: ${VERSION_CODES.M} == ${VERSION.SDK_INT}")
+        if (DEBUG) Log.d(LOG_TAG, "Firewall mode : $firewallMode, braveMode: $braveMode, SDK_Version: ${VERSION_CODES.M} == ${VERSION.SDK_INT}")
         appMode?.setFirewallMode(firewallMode)
 
-        if(braveMode == FIREWALL_MODE){
+        if (braveMode == FIREWALL_MODE) {
             appMode?.setDNSMode(Settings.DNSModeNone)
-        }else{
+        } else {
             appMode?.setDNSMode(-1)
         }
 
@@ -536,12 +534,16 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         persistentState.setBraveMode(braveMode)
 
         if (VpnController.getInstance()!!.getState(requireContext())!!.activationRequested) {
-            if (braveMode == 0){
-                b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_dns_connected))
-            }else if (braveMode == 1) {
-                b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_firewall_connected))
-            } else {
-                b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_connected))
+            when (braveMode) {
+                0 -> {
+                    b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_dns_connected)
+                }
+                1 -> {
+                    b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_firewall_connected)
+                }
+                else -> {
+                    b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_connected)
+                }
             }
         }
 
@@ -565,8 +567,7 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
     }
 
     // TODO : The data has been hardcoded need to modify
-    @SuppressLint("ResourceType")
-    private fun getAllModes(): ArrayList<BraveMode> {
+    @SuppressLint("ResourceType") private fun getAllModes(): ArrayList<BraveMode> {
         val braveNames = resources.getStringArray(R.array.brave_dns_mode_names)
         val icons = resources.obtainTypedArray(R.array.brave_dns_mode_icons)
         val braveList = ArrayList<BraveMode>(3)
@@ -580,14 +581,10 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         return braveList
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
-    }
-
 
     private val messageReceiver: BroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
-          if (InternalNames.DNS_STATUS.name == intent.action) {
+            if (InternalNames.DNS_STATUS.name == intent.action) {
                 syncDnsStatus()
             }
         }
@@ -600,17 +597,17 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
 
     private fun updateUptime() {
         val upTime = DateUtils.getRelativeTimeSpanString(appStartTime, System.currentTimeMillis(), MINUTE_IN_MILLIS, FORMAT_ABBREV_RELATIVE)
-        b.fhsAppUptime.setText("($upTime)")
+        b.fhsAppUptime.text = "($upTime)"
     }
 
     private fun prepareAndStartDnsVpn() {
         if (hasVpnService()) {
             if (prepareVpnService()) {
-                b.fhsDnsOnOffBtn.setText("stop")
+                b.fhsDnsOnOffBtn.text = "stop"
                 b.fhsDnsOnOffBtn.setBackgroundResource(R.drawable.rounded_corners_button_accent)
                 updateUIForStart()
                 startDnsVpnService()
-                if(DEBUG) Log.d(LOG_TAG, "VPN service start initiated - startDnsVpnService()")
+                if (DEBUG) Log.d(LOG_TAG, "VPN service start initiated - startDnsVpnService()")
             }
         } else {
             Log.e("BraveVPN", "Device does not support system-wide VPN mode.")
@@ -622,7 +619,7 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         shimmerForStart()
     }
 
-    private fun shimmerForStart(){
+    private fun shimmerForStart() {
         val builder = Shimmer.AlphaHighlightBuilder()
         builder.setDuration(10000)
         builder.setBaseAlpha(0.85f)
@@ -631,7 +628,7 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         b.shimmerViewContainer1.setShimmer(builder.build())
     }
 
-    private fun shimmerForStop(){
+    private fun shimmerForStop() {
         val builder = Shimmer.AlphaHighlightBuilder()
         builder.setDuration(2000)
         builder.setBaseAlpha(0.85f)
@@ -640,7 +637,7 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         b.shimmerViewContainer1.setShimmer(builder.build())
     }
 
-    private fun updateUIForStop(){
+    private fun updateUIForStop() {
         disableBraveModeIcon()
         shimmerForStop()
     }
@@ -652,11 +649,11 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
     private fun startDnsVpnService() {
         VpnController.getInstance()?.start(requireContext())
         if (braveMode == 0) {
-            b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_dns_connected))
+            b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_dns_connected)
         } else if (braveMode == 1) {
-            b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_firewall_connected))
+            b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_firewall_connected)
         } else {
-            b.fhsAppConnectedDesc.setText(getString(R.string.dns_explanation_connected))
+            b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_connected)
         }
     }
 
@@ -665,8 +662,7 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         return VERSION.SDK_INT >= VERSION_CODES.ICE_CREAM_SANDWICH
     }
 
-    @Throws(ActivityNotFoundException::class)
-    private fun prepareVpnService(): Boolean {
+    @Throws(ActivityNotFoundException::class) private fun prepareVpnService(): Boolean {
         var prepareVpnIntent: Intent? = null
         prepareVpnIntent = try {
             VpnService.prepare(context)
@@ -702,12 +698,9 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         if (status!!.activationRequested || status.connectionState == BraveVPNService.State.WORKING) {
             b.fhsDnsOnOffBtn.setBackgroundResource(R.drawable.rounded_corners_button_accent)
             b.fhsDnsOnOffBtn.text = "stop"
-            if (braveMode == 0)
-                b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_dns_connected)
-            else if (braveMode == 1)
-                b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_firewall_connected)
-            else
-                b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_connected)
+            if (braveMode == 0) b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_dns_connected)
+            else if (braveMode == 1) b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_firewall_connected)
+            else b.fhsAppConnectedDesc.text = getString(R.string.dns_explanation_connected)
         } else {
             b.fhsDnsOnOffBtn.setBackgroundResource(R.drawable.rounded_corners_button_primary)
             updateUIForStop()
@@ -720,46 +713,55 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         val explanationId: Int
         var privateDnsMode: PrivateDnsMode = PrivateDnsMode.NONE
         if (status.activationRequested) {
-            if (status.connectionState == null) {
-                statusId = R.string.status_waiting
-                explanationId = R.string.explanation_offline
-            } else if (status.connectionState === BraveVPNService.State.NEW) {
-                statusId = R.string.status_starting
-                explanationId = R.string.explanation_starting
-            } else if (status.connectionState === BraveVPNService.State.WORKING) {
-                statusId = R.string.status_protected
-                explanationId = R.string.explanation_protected
-            } else {
-                statusId = R.string.status_failing
-                explanationId = R.string.explanation_failing
+            when {
+                status.connectionState == null -> {
+                    statusId = R.string.status_waiting
+                    explanationId = R.string.explanation_offline
+                }
+                status.connectionState === BraveVPNService.State.NEW -> {
+                    statusId = R.string.status_starting
+                    explanationId = R.string.explanation_starting
+                }
+                status.connectionState === BraveVPNService.State.WORKING -> {
+                    statusId = R.string.status_protected
+                    explanationId = R.string.explanation_protected
+                }
+                else -> {
+                    statusId = R.string.status_failing
+                    explanationId = R.string.explanation_failing
+                }
             }
         } else if (isAnotherVpnActive()) {
             statusId = R.string.status_exposed
             explanationId = R.string.explanation_vpn
         } else {
             privateDnsMode = getPrivateDnsMode()
-            if (privateDnsMode == PrivateDnsMode.STRICT) {
-                statusId = R.string.status_strict
-                explanationId = R.string.explanation_strict
-            } else if (privateDnsMode == PrivateDnsMode.UPGRADED) {
-                statusId = R.string.status_exposed
-                explanationId = R.string.explanation_upgraded
-            } else {
-                statusId = R.string.status_exposed
-                explanationId = R.string.explanation_exposed
+            when (privateDnsMode) {
+                PrivateDnsMode.STRICT -> {
+                    statusId = R.string.status_strict
+                    explanationId = R.string.explanation_strict
+                }
+                PrivateDnsMode.UPGRADED -> {
+                    statusId = R.string.status_exposed
+                    explanationId = R.string.explanation_upgraded
+                }
+                else -> {
+                    statusId = R.string.status_exposed
+                    explanationId = R.string.explanation_exposed
+                }
             }
         }
-        if(DEBUG) Log.d(LOG_TAG, "Status - ${status.activationRequested}, ${status.connectionState}")
+        if (DEBUG) Log.d(LOG_TAG, "Status - ${status.activationRequested}, ${status.connectionState}")
 
-        if(status.connectionState == BraveVPNService.State.WORKING){
+        if (status.connectionState == BraveVPNService.State.WORKING) {
             statusId = R.string.status_protected
         }
 
-        if(braveMode == 1 && status.activationRequested){
+        if (braveMode == 1 && status.activationRequested) {
             statusId = R.string.status_protected
         }
 
-        if(appMode?.getDNSType() == 3 && status.activationRequested){
+        if (appMode?.getDNSType() == 3 && status.activationRequested) {
             statusId = R.string.status_protected
         }
 
@@ -773,8 +775,7 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
         } else {
             R.color.accent_bad
         }
-        if (braveMode == FIREWALL_MODE && status.activationRequested)
-            colorId = R.color.positive
+        if (braveMode == FIREWALL_MODE && status.activationRequested) colorId = R.color.positive
 
         val color = ContextCompat.getColor(requireContext(), colorId)
         b.fhsProtectionLevelTxt.setTextColor(color)
@@ -787,8 +788,7 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
             // Private DNS was introduced in P.
             return PrivateDnsMode.NONE
         }
-        val linkProperties: LinkProperties = getLinkProperties()
-            ?: return PrivateDnsMode.NONE
+        val linkProperties: LinkProperties = getLinkProperties() ?: return PrivateDnsMode.NONE
         if (linkProperties.privateDnsServerName != null) {
             return PrivateDnsMode.STRICT
         }
@@ -798,8 +798,7 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
     }
 
     private fun getLinkProperties(): LinkProperties? {
-        val connectivityManager =
-            requireContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val connectivityManager = requireContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         if (VERSION.SDK_INT < VERSION_CODES.M) {
             // getActiveNetwork() requires M or later.
             return null
@@ -810,26 +809,20 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
 
     private fun isAnotherVpnActive(): Boolean {
         if (VERSION.SDK_INT >= VERSION_CODES.M) {
-            val connectivityManager =
-                requireContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            val connectivityManager = requireContext().getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
             val activeNetwork = connectivityManager.activeNetwork ?: return false
-            val capabilities =
-                connectivityManager.getNetworkCapabilities(activeNetwork)
-                    ?: // It's not clear when this can happen, but it has occurred for at least one user.
-                    return false
+            val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: // It's not clear when this can happen, but it has occurred for at least one user.
+            return false
             return capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)
         }
         // For pre-M versions, return true if there's any network whose name looks like a VPN.
         try {
-            val networkInterfaces =
-                NetworkInterface.getNetworkInterfaces()
+            val networkInterfaces = NetworkInterface.getNetworkInterfaces()
             while (networkInterfaces.hasMoreElements()) {
                 val networkInterface = networkInterfaces.nextElement()
                 val name = networkInterface.name
 
-                if (networkInterface.isUp && name != null &&
-                    (name.startsWith("tun") || name.startsWith("pptp") || name.startsWith("l2tp"))
-                ) {
+                if (networkInterface.isUp && name != null && (name.startsWith("tun") || name.startsWith("pptp") || name.startsWith("l2tp"))) {
                     return true
                 }
             }

--- a/app/src/main/java/com/celzero/bravedns/ui/HomeScreenSettingBottomSheet.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/HomeScreenSettingBottomSheet.kt
@@ -4,10 +4,11 @@ import android.os.Build
 import android.os.Bundle
 import android.text.format.DateUtils
 import android.util.Log
+import android.view.LayoutInflater
 import android.view.View
+import android.view.ViewGroup
 import android.widget.RadioButton
 import android.widget.RadioGroup
-import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.databinding.BottomSheetHomeScreenBinding
 import com.celzero.bravedns.service.PersistentState
@@ -19,13 +20,28 @@ import org.koin.android.ext.android.inject
 import settings.Settings
 
 class HomeScreenSettingBottomSheet(var connectedDetails: String) : BottomSheetDialogFragment() {
-    private val b by viewBinding(BottomSheetHomeScreenBinding::bind)
+    private var _binding: BottomSheetHomeScreenBinding? = null
+
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val b get() = _binding!!
+
     private var firewallMode = -1L
     private val LOG_FILE = "HOMESCREEN_BTM_SHEET"
 
     private val persistentState by inject<PersistentState>()
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = BottomSheetHomeScreenBinding.inflate(inflater, container, false)
+        return b.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/java/com/celzero/bravedns/ui/HomeScreenSettingBottomSheet.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/HomeScreenSettingBottomSheet.kt
@@ -4,13 +4,12 @@ import android.os.Build
 import android.os.Bundle
 import android.text.format.DateUtils
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.RadioButton
 import android.widget.RadioGroup
-import android.widget.TextView
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
+import com.celzero.bravedns.databinding.BottomSheetHomeScreenBinding
 import com.celzero.bravedns.service.PersistentState
 import com.celzero.bravedns.service.VpnController
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
@@ -19,12 +18,8 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.koin.android.ext.android.inject
 import settings.Settings
 
-class HomeScreenSettingBottomSheet(var connectedDetails : String) : BottomSheetDialogFragment() {
-
-    private var fragmentView: View? = null
-    private lateinit var appUpTimeTxt : TextView
-    private lateinit var connectedStatusTxt : TextView
-    private lateinit var braveModeRadioGroup: RadioGroup
+class HomeScreenSettingBottomSheet(var connectedDetails: String) : BottomSheetDialogFragment() {
+    private val b by viewBinding(BottomSheetHomeScreenBinding::bind)
     private var firewallMode = -1L
     private val LOG_FILE = "HOMESCREEN_BTM_SHEET"
 
@@ -32,55 +27,50 @@ class HomeScreenSettingBottomSheet(var connectedDetails : String) : BottomSheetD
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        fragmentView = inflater.inflate(R.layout.bottom_sheet_home_screen, container, false)
-        return fragmentView
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        initView(view)
+        initView()
         updateUptime()
         initializeClickListeners()
     }
 
-    private fun initView(view: View) {
-        braveModeRadioGroup = view.findViewById(R.id.bs_home_screen_radio_group)
-        appUpTimeTxt = view.findViewById(R.id.bs_home_screen_app_uptime)
-        connectedStatusTxt = view.findViewById(R.id.bs_home_screen_connected_status)
-        connectedStatusTxt.text = connectedDetails
+    private fun initView() {
+        b.bsHomeScreenConnectedStatus.text = connectedDetails
         var selectedIndex = HomeScreenActivity.GlobalVariable.braveMode
-        if(DEBUG) Log.d(LOG_TAG,"$LOG_FILE - selectedIndex: $selectedIndex")
-        if(selectedIndex != -1) {
-            (braveModeRadioGroup.getChildAt(selectedIndex) as RadioButton).isChecked = true
-        }else{
-            selectedIndex =  persistentState.getBraveMode()
-            (braveModeRadioGroup.getChildAt(selectedIndex) as RadioButton).isChecked = true
+        if (DEBUG) Log.d(LOG_TAG, "$LOG_FILE - selectedIndex: $selectedIndex")
+        if (selectedIndex != -1) {
+            (b.bsHomeScreenRadioGroup.getChildAt(selectedIndex) as RadioButton).isChecked = true
+        } else {
+            selectedIndex = persistentState.getBraveMode()
+            (b.bsHomeScreenRadioGroup.getChildAt(selectedIndex) as RadioButton).isChecked = true
         }
     }
 
     private fun initializeClickListeners() {
-        braveModeRadioGroup.setOnCheckedChangeListener{ radioGroup: RadioGroup, i: Int ->
-            if(i == R.id.bs_home_screen_radio_dns){
-                firewallMode = Settings.BlockModeNone
-                HomeScreenActivity.GlobalVariable.braveMode = HomeScreenFragment.DNS_MODE
-            }else if(i == R.id.bs_home_screen_radio_firewall){
-                firewallMode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) Settings.BlockModeFilterProc
-                else Settings.BlockModeFilter
-                HomeScreenActivity.GlobalVariable.braveMode = HomeScreenFragment.FIREWALL_MODE
-            }else if(i == R.id.bs_home_screen_radio_dns_firewall){
-                firewallMode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) Settings.BlockModeFilterProc
-                else Settings.BlockModeFilter
-                HomeScreenActivity.GlobalVariable.braveMode = HomeScreenFragment.DNS_FIREWALL_MODE
+        b.bsHomeScreenRadioGroup.setOnCheckedChangeListener { _: RadioGroup, i: Int ->
+            when (i) {
+                R.id.bs_home_screen_radio_dns -> {
+                    firewallMode = Settings.BlockModeNone
+                    HomeScreenActivity.GlobalVariable.braveMode = HomeScreenFragment.DNS_MODE
+                }
+                R.id.bs_home_screen_radio_firewall -> {
+                    firewallMode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) Settings.BlockModeFilterProc
+                    else Settings.BlockModeFilter
+                    HomeScreenActivity.GlobalVariable.braveMode = HomeScreenFragment.FIREWALL_MODE
+                }
+                R.id.bs_home_screen_radio_dns_firewall -> {
+                    firewallMode = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) Settings.BlockModeFilterProc
+                    else Settings.BlockModeFilter
+                    HomeScreenActivity.GlobalVariable.braveMode = HomeScreenFragment.DNS_FIREWALL_MODE
+                }
             }
             modifyBraveMode()
         }
     }
 
     private fun updateUptime() {
-        val upTime = DateUtils.getRelativeTimeSpanString(HomeScreenActivity.GlobalVariable.appStartTime,
-            System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE)
-        appUpTimeTxt.text = "($upTime)"
+        val upTime = DateUtils.getRelativeTimeSpanString(HomeScreenActivity.GlobalVariable.appStartTime, System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE)
+        b.bsHomeScreenAppUptime.text = "($upTime)"
     }
 
     private fun modifyBraveMode() {
@@ -93,12 +83,16 @@ class HomeScreenSettingBottomSheet(var connectedDetails : String) : BottomSheetD
         persistentState.setBraveMode(HomeScreenActivity.GlobalVariable.braveMode)
         HomeScreenActivity.GlobalVariable.braveModeToggler.postValue(HomeScreenActivity.GlobalVariable.braveMode)
         if (VpnController.getInstance()!!.getState(requireContext())!!.activationRequested) {
-            if (HomeScreenActivity.GlobalVariable.braveMode == 0) {
-                connectedStatusTxt.text = getString(R.string.dns_explanation_dns_connected)
-            } else if (HomeScreenActivity.GlobalVariable.braveMode == 1) {
-                connectedStatusTxt.text = getString(R.string.dns_explanation_firewall_connected)
-            } else {
-                connectedStatusTxt.text = getString(R.string.dns_explanation_connected)
+            when (HomeScreenActivity.GlobalVariable.braveMode) {
+                0 -> {
+                    b.bsHomeScreenConnectedStatus.text = getString(R.string.dns_explanation_dns_connected)
+                }
+                1 -> {
+                    b.bsHomeScreenConnectedStatus.text = getString(R.string.dns_explanation_firewall_connected)
+                }
+                else -> {
+                    b.bsHomeScreenConnectedStatus.text = getString(R.string.dns_explanation_connected)
+                }
             }
             //enableBraveModeIcons()
         }

--- a/app/src/main/java/com/celzero/bravedns/ui/InternetManagerFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/InternetManagerFragment.kt
@@ -24,6 +24,7 @@ import android.view.accessibility.AccessibilityManager
 import android.widget.Toast
 import androidx.fragment.app.Fragment
 import by.kirich1409.viewbindingdelegate.viewBinding
+import com.celzero.bravedns.R
 import com.celzero.bravedns.databinding.FragmentInternetManagerBinding
 import com.celzero.bravedns.util.MyAccessibilityService
 
@@ -33,7 +34,7 @@ import com.celzero.bravedns.service.ServiceState
 import com.celzero.bravedns.service.getServiceState*/
 
 
-class InternetManagerFragment : Fragment() {
+class InternetManagerFragment : Fragment(R.layout.fragment_internet_manager) {
     private val b by viewBinding(FragmentInternetManagerBinding::bind)
     private var contextVal: Context? = null
 

--- a/app/src/main/java/com/celzero/bravedns/ui/InternetManagerFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/InternetManagerFragment.kt
@@ -19,16 +19,14 @@ import android.content.Context
 import android.content.Context.ACCESSIBILITY_SERVICE
 import android.content.Intent
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.view.accessibility.AccessibilityManager
-import android.widget.Button
 import android.widget.Toast
-import android.widget.ToggleButton
 import androidx.fragment.app.Fragment
-import com.celzero.bravedns.R
+import by.kirich1409.viewbindingdelegate.viewBinding
+import com.celzero.bravedns.databinding.FragmentInternetManagerBinding
 import com.celzero.bravedns.util.MyAccessibilityService
+
 /*import com.celzero.bravedns.service.Actions
 import com.celzero.bravedns.service.BackgroundService
 import com.celzero.bravedns.service.ServiceState
@@ -36,20 +34,12 @@ import com.celzero.bravedns.service.getServiceState*/
 
 
 class InternetManagerFragment : Fragment() {
+    private val b by viewBinding(FragmentInternetManagerBinding::bind)
+    private var contextVal: Context? = null
 
-    private lateinit var adToggle : ToggleButton
-    private lateinit var contentToggle : ToggleButton
-    private var contextVal : Context ?= null
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        val view: View = inflater.inflate(R.layout.fragment_internet_manager,container,false)
-
-        initView(view)
-        return view
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initView()
     }
 
     override fun onAttach(context: Context) {
@@ -57,30 +47,24 @@ class InternetManagerFragment : Fragment() {
         super.onAttach(context)
     }
 
-    private fun initView(view:View) {
-        adToggle = view.findViewById(R.id.toggle_ad_blocker)
-        contentToggle = view.findViewById(R.id.toggle_content_blocker)
+    private fun initView() {
 
         //Code which needs to be removed
         //For testing purpose
         //Need to delete
-        val testButton : Button = view.findViewById(R.id.test_val)
 
-        testButton.setOnClickListener {
-            Toast.makeText(contextVal,"Test1",Toast.LENGTH_SHORT).show()
+        b.testVal.setOnClickListener {
+            Toast.makeText(contextVal, "Test1", Toast.LENGTH_SHORT).show()
             val intent = Intent(this.contextVal, UniversalFirewallFragment::class.java)
             startActivity(intent)
         }
 
-        val testButton1 : Button = view.findViewById(R.id.test_val1)
-
-        testButton1.setOnClickListener {
-            Toast.makeText(contextVal,"Test1",Toast.LENGTH_SHORT).show()
+        b.testVal1.setOnClickListener {
+            Toast.makeText(contextVal, "Test1", Toast.LENGTH_SHORT).show()
             val intent = Intent(this.contextVal, PermissionManagerActivity::class.java)
             startActivity(intent)
         }
 
-        val testButton2 : Button = view.findViewById(R.id.test_val2)
 
         /*testButton2.setOnClickListener {
             Toast.makeText(contextVal,"Test2",Toast.LENGTH_SHORT).show()
@@ -97,33 +81,28 @@ class InternetManagerFragment : Fragment() {
         //Above code for testing
 
 
-        adToggle.setOnCheckedChangeListener { buttonView, isChecked ->
+        b.toggleAdBlocker.setOnCheckedChangeListener { buttonView, isChecked ->
             if (isChecked) {
                 val am = context?.getSystemService(ACCESSIBILITY_SERVICE) as AccessibilityManager?
                 val isAccessibilityEnabled = am!!.isEnabled
-                if(isAccessibilityEnabled)
-                    openNetworkDashboardActivity(true)
+                if (isAccessibilityEnabled) openNetworkDashboardActivity(true)
                 else {
-                    Toast.makeText(
-                        context,
-                        "Please enable Accessibility Service to proceed further",
-                        Toast.LENGTH_LONG
-                    ).show()
+                    Toast.makeText(context, "Please enable Accessibility Service to proceed further", Toast.LENGTH_LONG).show()
                     buttonView.isChecked = false
                 }
             } else {
-                Toast.makeText(context,"Turned Off",Toast.LENGTH_LONG).show()
+                Toast.makeText(context, "Turned Off", Toast.LENGTH_LONG).show()
                 openNetworkDashboardActivity(false)
             }
         }
 
 
-        contentToggle.setOnClickListener{
-            Toast.makeText(context, "Coming Soon!",Toast.LENGTH_SHORT).show()
+        b.toggleContentBlocker.setOnClickListener {
+            Toast.makeText(context, "Coming Soon!", Toast.LENGTH_SHORT).show()
         }
     }
 
-    private fun openNetworkDashboardActivity(bool : Boolean) {
+    private fun openNetworkDashboardActivity(bool: Boolean) {
         val i = Intent("android.settings.WIRELESS_SETTINGS")
         i.setPackage("com.android.settings")
         i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)

--- a/app/src/main/java/com/celzero/bravedns/ui/PermissionManagerActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/PermissionManagerActivity.kt
@@ -21,11 +21,9 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.PermissionManagerApk
-import com.celzero.bravedns.database.AppDatabase
 import com.celzero.bravedns.database.AppInfoRepository
+import com.celzero.bravedns.databinding.ActivityPermissionManagerBinding
 import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.adapters.ItemAdapter
 import kotlinx.coroutines.Dispatchers
@@ -34,23 +32,21 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.android.ext.android.inject
 
-class PermissionManagerActivity: AppCompatActivity(), SearchView.OnQueryTextListener{
-
+class PermissionManagerActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
+    private lateinit var b: ActivityPermissionManagerBinding
     private lateinit var fastAdapter: FastAdapter<PermissionManagerApk>
-    private lateinit var recycle : RecyclerView
     val apkList = ArrayList<PermissionManagerApk>()
     lateinit var itemAdapter: ItemAdapter<PermissionManagerApk>
-    private lateinit var context : Context
-
-    private var editSearch: SearchView? = null
+    private lateinit var context: Context
 
     private val appInfoRepository by inject<AppInfoRepository>()
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_permission_manager)
-        Toast.makeText(this,"Permission Manager Activity", Toast.LENGTH_LONG).show()
+        b = ActivityPermissionManagerBinding.inflate(layoutInflater)
+        setContentView(b.root)
+        Toast.makeText(this, "Permission Manager Activity", Toast.LENGTH_LONG).show()
         initView()
 
         context = this
@@ -64,16 +60,14 @@ class PermissionManagerActivity: AppCompatActivity(), SearchView.OnQueryTextList
 
     private fun initView() {
 
-        recycle = findViewById(R.id.permission_manager_recycler_view)
-        recycle.layoutManager = LinearLayoutManager(this)
+        b.permissionManagerRecyclerView.layoutManager = LinearLayoutManager(this)
 
-        itemAdapter =  ItemAdapter()
+        itemAdapter = ItemAdapter()
         fastAdapter = FastAdapter.with(itemAdapter)
-        editSearch = findViewById(R.id.permission_manager_search)
 
-        editSearch!!.setOnQueryTextListener(this)
+        b.permissionManagerSearch.setOnQueryTextListener(this)
 
-        recycle.adapter = fastAdapter
+        b.permissionManagerRecyclerView.adapter = fastAdapter
     }
 
     override fun onQueryTextSubmit(query: String?): Boolean {
@@ -84,12 +78,11 @@ class PermissionManagerActivity: AppCompatActivity(), SearchView.OnQueryTextList
         return false
     }
 
-    private fun updateAppList() = GlobalScope.launch ( Dispatchers.Default ){
+    private fun updateAppList() = GlobalScope.launch(Dispatchers.Default) {
         val appList = appInfoRepository.getAppInfoAsync()
         //Log.w("DB","App list from DB Size: "+appList.size)
-        appList.forEach{
-
-            val userApk = PermissionManagerApk(packageManager.getPackageInfo(it.packageInfo,0), context)
+        appList.forEach {
+            val userApk = PermissionManagerApk(packageManager.getPackageInfo(it.packageInfo, 0), context)
             apkList.add(userApk)
         }
         withContext(Dispatchers.Main.immediate) {

--- a/app/src/main/java/com/celzero/bravedns/ui/PermissionManagerActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/PermissionManagerActivity.kt
@@ -21,6 +21,8 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.SearchView
 import androidx.recyclerview.widget.LinearLayoutManager
+import by.kirich1409.viewbindingdelegate.viewBinding
+import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.PermissionManagerApk
 import com.celzero.bravedns.database.AppInfoRepository
 import com.celzero.bravedns.databinding.ActivityPermissionManagerBinding
@@ -32,8 +34,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.android.ext.android.inject
 
-class PermissionManagerActivity : AppCompatActivity(), SearchView.OnQueryTextListener {
-    private lateinit var b: ActivityPermissionManagerBinding
+class PermissionManagerActivity : AppCompatActivity(R.layout.activity_permission_manager), SearchView.OnQueryTextListener {
+    private val b by viewBinding(ActivityPermissionManagerBinding::bind)
+
     private lateinit var fastAdapter: FastAdapter<PermissionManagerApk>
     val apkList = ArrayList<PermissionManagerApk>()
     lateinit var itemAdapter: ItemAdapter<PermissionManagerApk>
@@ -44,8 +47,6 @@ class PermissionManagerActivity : AppCompatActivity(), SearchView.OnQueryTextLis
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        b = ActivityPermissionManagerBinding.inflate(layoutInflater)
-        setContentView(b.root)
         Toast.makeText(this, "Permission Manager Activity", Toast.LENGTH_LONG).show()
         initView()
 

--- a/app/src/main/java/com/celzero/bravedns/ui/SettingsBottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/SettingsBottomSheetFragment.kt
@@ -15,23 +15,14 @@ limitations under the License.
 */
 package com.celzero.bravedns.ui
 
-import android.os.Bundle
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.databinding.ActivitySettingsScreenBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 class SettingsBottomSheetFragment : BottomSheetDialogFragment() {
-    private var _binding: ActivitySettingsScreenBinding? = null
-    private val b get() = _binding!!
+    private val b by viewBinding(ActivitySettingsScreenBinding::bind)
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        _binding = ActivitySettingsScreenBinding.inflate(inflater, container, false)
-        return b.root
-    }
 
 }

--- a/app/src/main/java/com/celzero/bravedns/ui/SettingsBottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/SettingsBottomSheetFragment.kt
@@ -15,37 +15,23 @@ limitations under the License.
 */
 package com.celzero.bravedns.ui
 
-import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.celzero.bravedns.R
+import com.celzero.bravedns.databinding.ActivitySettingsScreenBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 class SettingsBottomSheetFragment : BottomSheetDialogFragment() {
-
-    private var fragmentView: View? = null
-
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-    }
+    private var _binding: ActivitySettingsScreenBinding? = null
+    private val b get() = _binding!!
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        fragmentView = inflater.inflate(R.layout.activity_settings_screen, container, false)
-
-        return fragmentView
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-    }
-
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        return super.onCreateDialog(savedInstanceState)
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = ActivitySettingsScreenBinding.inflate(inflater, container, false)
+        return b.root
     }
 
 }

--- a/app/src/main/java/com/celzero/bravedns/ui/SettingsBottomSheetFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/SettingsBottomSheetFragment.kt
@@ -15,14 +15,31 @@ limitations under the License.
 */
 package com.celzero.bravedns.ui
 
-import by.kirich1409.viewbindingdelegate.viewBinding
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import com.celzero.bravedns.R
 import com.celzero.bravedns.databinding.ActivitySettingsScreenBinding
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 class SettingsBottomSheetFragment : BottomSheetDialogFragment() {
-    private val b by viewBinding(ActivitySettingsScreenBinding::bind)
+    private var _binding: ActivitySettingsScreenBinding? = null
+
+    // This property is only valid between onCreateView and
+    // onDestroyView.
+    private val b get() = _binding!!
 
     override fun getTheme(): Int = R.style.BottomSheetDialogTheme
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = ActivitySettingsScreenBinding.inflate(inflater, container, false)
+        return b.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 
 }

--- a/app/src/main/java/com/celzero/bravedns/ui/UniversalFirewallFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/UniversalFirewallFragment.kt
@@ -20,24 +20,22 @@ import android.os.Bundle
 import android.os.Handler
 import android.provider.Settings
 import android.util.Log
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-import android.widget.*
+import android.widget.CompoundButton
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
-import androidx.appcompat.widget.SwitchCompat
-import androidx.cardview.widget.CardView
 import androidx.core.content.ContextCompat
-import androidx.core.widget.NestedScrollView
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.adapter.UniversalAppListAdapter
 import com.celzero.bravedns.adapter.UniversalBlockedRulesAdapter
 import com.celzero.bravedns.database.AppInfoRepository
 import com.celzero.bravedns.database.BlockedConnectionsRepository
+import com.celzero.bravedns.databinding.UniversalFragementContainerBinding
 import com.celzero.bravedns.service.BraveVPNService
 import com.celzero.bravedns.service.PersistentState
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable
@@ -57,166 +55,95 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
  * TODO: Search feature is removed for firewall header testing
  */
 
-class UniversalFirewallFragment : Fragment() , SearchView.OnQueryTextListener {
+class UniversalFirewallFragment : Fragment(R.layout.universal_fragement_container), SearchView.OnQueryTextListener {
+    private val b by viewBinding(UniversalFragementContainerBinding::bind)
 
-    private lateinit var firewallAllAppsToggle : SwitchCompat
-    private lateinit var firewallAllAppsTxt : TextView
-
-    private lateinit var universalFirewallTxt : TextView
-    private lateinit var screenLockLL : LinearLayout
-    private lateinit var allAppBgLL : LinearLayout
-
-    private lateinit var whiteListHeader : RelativeLayout
-    private lateinit var whiteListExpTxt : TextView
-    private lateinit var whitelistCountTxt : TextView
-
-    private lateinit var ipRulesHeader : TextView
-    private lateinit var ipSearchView: SearchView
-    private lateinit var ipSearchViewContainer : LinearLayout
-    private lateinit var ipRulesExpTxt : TextView
-    private lateinit var ipRulesNoRulesSetTxt : TextView
-    private lateinit var ipRulesDeleteBtn : ImageView
-    //private lateinit var ipRulesAddBtn : ImageView
-    private lateinit var ipSearchCardContainer : CardView
-
-    private lateinit var  firewallNotEnabledLL : LinearLayout
-
-    private lateinit var backboardModeToggleText : TextView
-    private lateinit var backgroundModeToggle : SwitchCompat
-
-    private lateinit var unknownToggleText : TextView
-    private lateinit var unknownToggle : SwitchCompat
-
-    private lateinit var udpBlockToggleText : TextView
-    private lateinit var udpBlockToggle : SwitchCompat
-
-    private lateinit var recyclerView: RecyclerView
-    private var recyclerAdapter : UniversalAppListAdapter ?= null
-    private var recyclerRulesAdapter : UniversalBlockedRulesAdapter?= null
+    private var recyclerAdapter: UniversalAppListAdapter? = null
+    private var recyclerRulesAdapter: UniversalBlockedRulesAdapter? = null
     private var layoutManager: RecyclerView.LayoutManager? = null
     private val viewModel: BlockedConnectionsViewModel by viewModel()
-    private val appInfoViewModel : AppListViewModel by viewModel()
+    private val appInfoViewModel: AppListViewModel by viewModel()
 
-    private var universalState : Boolean = false
-    private var ipListState : Boolean = false
+    private var universalState: Boolean = false
+    private var ipListState: Boolean = false
 
     private val appInfoRepository by inject<AppInfoRepository>()
     private val blockedConnectionsRepository by inject<BlockedConnectionsRepository>()
     private val persistentState by inject<PersistentState>()
 
-    private lateinit var scrollView : NestedScrollView
-
     companion object {
         fun newInstance() = UniversalFirewallFragment()
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        super.onCreate(savedInstanceState)
-        val view: View = inflater.inflate(R.layout.universal_fragement_container, container, false)
-        if(DEBUG) Log.d(LOG_TAG, "UniversalFirewallFragment - onCreateView")
-        initView(view)
-        return view
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         viewModel.blockedUnivRulesList.observe(viewLifecycleOwner, androidx.lifecycle.Observer(recyclerRulesAdapter!!::submitList))
         appInfoViewModel.appDetailsList.observe(viewLifecycleOwner, androidx.lifecycle.Observer(recyclerAdapter!!::submitList))
         super.onViewCreated(view, savedInstanceState)
+        initView()
     }
 
-    private fun initView(view: View) {
-        val includeView = view.findViewById<View>(R.id.app_scrolling_incl_firewall)
-        scrollView = includeView as NestedScrollView
-        //scrollView = view.findViewById(R.id.firewall_scroll_view)
-        firewallNotEnabledLL = includeView.findViewById(R.id.firewall_scroll_connect_check)
-        universalFirewallTxt = includeView.findViewById(R.id.firewall_universal_top_text)
-        screenLockLL = includeView.findViewById(R.id.firewall_screen_ll)
-        allAppBgLL = includeView.findViewById(R.id.firewall_background_ll)
-        recyclerView = includeView.findViewById<View>(R.id.firewall_universal_recycler) as RecyclerView
+    private fun initView() {
+        val includeView = b.appScrollingInclFirewall
 
-
-        ipSearchView = includeView.findViewById(R.id.firewall_search_view)
-        ipSearchViewContainer = includeView.findViewById(R.id.firewall_search_view_top)
-        ipRulesExpTxt = includeView.findViewById(R.id.firewall_univ_whitelist_rules_exp_txt)
-        ipRulesNoRulesSetTxt = includeView.findViewById(R.id.firewall_no_rules_set_txt)
-        //ipRulesAddBtn = includeView.findViewById(R.id.firewall_search_add_icon)
-        ipRulesDeleteBtn = includeView.findViewById(R.id.firewall_search_delete_icon)
-        ipSearchCardContainer = includeView.findViewById(R.id.firewall_search_container)
-
-        whiteListHeader = includeView.findViewById(R.id.firewall_apps_show_txt)
-        whiteListExpTxt = includeView.findViewById(R.id.firewall_univ_whitelist_exp_txt)
-        whitelistCountTxt = includeView.findViewById(R.id.firewall_univ_whitelist_count)
-
-        ipRulesHeader = includeView.findViewById(R.id.firewall_rules_show_txt)
         val isServiceRunning = Utilities.isServiceRunning(requireContext(), BraveVPNService::class.java)
 
-        if(!isServiceRunning){
-            firewallNotEnabledLL.visibility = View.GONE
+        if (!isServiceRunning) {
+            includeView.firewallScrollConnectCheck.visibility = View.GONE
             return
-        }else{
-            firewallNotEnabledLL.visibility = View.VISIBLE
+        } else {
+            includeView.firewallScrollConnectCheck.visibility = View.VISIBLE
         }
 
         setIPRulesVisible()
 
-        recyclerView.setHasFixedSize(true)
+        includeView.firewallUniversalRecycler.setHasFixedSize(true)
         layoutManager = LinearLayoutManager(requireContext())
-        recyclerView.layoutManager = layoutManager
+        includeView.firewallUniversalRecycler.layoutManager = layoutManager
         recyclerRulesAdapter = UniversalBlockedRulesAdapter(requireContext(), blockedConnectionsRepository)
         recyclerAdapter = UniversalAppListAdapter(requireContext(), appInfoRepository, get(), persistentState)
-        recyclerView.adapter = recyclerRulesAdapter
-        ipSearchView.requestFocus()
+        includeView.firewallUniversalRecycler.adapter = recyclerRulesAdapter
+        includeView.firewallSearchView.requestFocus()
 
         //recyclerView.isNestedScrollingEnabled = false
         //ViewCompat.setNestedScrollingEnabled(recyclerView, false)
 
-        if(DEBUG) Log.d(LOG_TAG, "UniversalFirewallFragment - post observer")
+        if (DEBUG) Log.d(LOG_TAG, "UniversalFirewallFragment - post observer")
 
-        //Firewall Toggle
-        firewallAllAppsToggle = includeView.findViewById(R.id.firewall_all_apps_check)
-        firewallAllAppsTxt = includeView.findViewById(R.id.firewall_all_apps_txt)
-        backgroundModeToggle = includeView.findViewById(R.id.firewall_background_mode_check)
-        backboardModeToggleText = includeView.findViewById(R.id.firewall_background_mode_txt)
-        unknownToggleText = includeView.findViewById(R.id.firewall_unknown_connection_mode_txt)
-        unknownToggle = includeView.findViewById(R.id.firewall_unknown_connection_mode_check)
-        udpBlockToggle = includeView.findViewById(R.id.firewall_udp_connection_mode_check)
-        udpBlockToggleText = includeView.findViewById(R.id.firewall_udp_connection_mode_txt)
+        includeView.firewallAllAppsCheck.isChecked = persistentState.getFirewallModeForScreenState()
 
-        firewallAllAppsToggle.isChecked = persistentState.getFirewallModeForScreenState()
+        includeView.firewallUdpConnectionModeCheck.isChecked = persistentState.udpBlockedSettings
+        includeView.firewallUnknownConnectionModeCheck.isChecked = persistentState.blockUnknownConnections
 
-        udpBlockToggle.isChecked = persistentState.udpBlockedSettings
-        unknownToggle.isChecked =  persistentState.blockUnknownConnections
-
-        firewallAllAppsToggle.setOnCheckedChangeListener { _, b ->
+        includeView.firewallAllAppsCheck.setOnCheckedChangeListener { _, b ->
             persistentState.setFirewallModeForScreenState(b)
         }
 
-        firewallAllAppsTxt.setOnClickListener {
-            if(persistentState.getFirewallModeForScreenState()){
-                firewallAllAppsToggle.isChecked = false
+        includeView.firewallAllAppsTxt.setOnClickListener {
+            if (persistentState.getFirewallModeForScreenState()) {
+                includeView.firewallAllAppsCheck.isChecked = false
                 persistentState.setFirewallModeForScreenState(false)
-            }else{
-                firewallAllAppsToggle.isChecked = true
+            } else {
+                includeView.firewallAllAppsCheck.isChecked = true
                 persistentState.setFirewallModeForScreenState(true)
             }
         }
 
-        unknownToggle.setOnCheckedChangeListener{ compoundButton: CompoundButton, b: Boolean ->
+        includeView.firewallUnknownConnectionModeCheck.setOnCheckedChangeListener { _: CompoundButton, b: Boolean ->
             persistentState.blockUnknownConnections = b
         }
 
-        unknownToggleText.setOnClickListener {
-            persistentState.blockUnknownConnections = !unknownToggle.isChecked
-            unknownToggle.isChecked = !unknownToggle.isChecked
+        includeView.firewallUnknownConnectionModeTxt.setOnClickListener {
+            persistentState.blockUnknownConnections = !includeView.firewallUnknownConnectionModeCheck.isChecked
+            includeView.firewallUnknownConnectionModeCheck.isChecked = !includeView.firewallUnknownConnectionModeCheck.isChecked
         }
 
-        udpBlockToggle.setOnCheckedChangeListener{ compoundButton: CompoundButton, b: Boolean ->
+        includeView.firewallUdpConnectionModeCheck.setOnCheckedChangeListener { _: CompoundButton, b: Boolean ->
             persistentState.udpBlockedSettings = b
         }
 
-        udpBlockToggleText.setOnClickListener{
-            persistentState.udpBlockedSettings = !udpBlockToggle.isChecked
-            udpBlockToggle.isChecked = !udpBlockToggle.isChecked
+        includeView.firewallUdpConnectionModeTxt.setOnClickListener {
+            persistentState.udpBlockedSettings = !includeView.firewallUdpConnectionModeCheck.isChecked
+            includeView.firewallUdpConnectionModeCheck.isChecked = !includeView.firewallUdpConnectionModeCheck.isChecked
         }
 
         /*ipRulesAddBtn.setOnClickListener{
@@ -224,54 +151,54 @@ class UniversalFirewallFragment : Fragment() , SearchView.OnQueryTextListener {
         }*/
 
         //Background mode toggle
-        backboardModeToggleText.setOnClickListener {
-            val checkedVal = backgroundModeToggle.isChecked
-            if(!checkedVal) {
-                if (Utilities.isAccessibilityServiceEnabledEnhanced(requireContext(), BackgroundAccessibilityService::class.java)) {
-                    if(!Utilities.isAccessibilityServiceEnabled(requireContext(), BackgroundAccessibilityService::class.java)){
-                        if (!showAlertForPermission(true)) {
-                            backgroundModeToggle.isChecked = false
-                            persistentState.setIsBackgroundEnabled(false)
-                        }
-                    }
-                    GlobalVariable.isBackgroundEnabled = !checkedVal
-                    persistentState.setIsBackgroundEnabled(!checkedVal)
-                    backgroundModeToggle.isChecked = !checkedVal
-                } else {
-                    if (!showAlertForPermission(false)) {
-                        backgroundModeToggle.isChecked = false
-                        persistentState.setIsBackgroundEnabled(false)
-                    }
-                }
-            }else{
-                backgroundModeToggle.isChecked = false
-                persistentState.setIsBackgroundEnabled(false)
-            }
-        }
-
-        backgroundModeToggle.setOnCheckedChangeListener(null)
-
-        backgroundModeToggle.setOnClickListener{
-            val checkedVal = !backgroundModeToggle.isChecked
+        includeView.firewallBackgroundModeTxt.setOnClickListener {
+            val checkedVal = includeView.firewallBackgroundModeCheck.isChecked
             if (!checkedVal) {
                 if (Utilities.isAccessibilityServiceEnabledEnhanced(requireContext(), BackgroundAccessibilityService::class.java)) {
-                    if(!Utilities.isAccessibilityServiceEnabled(requireContext(), BackgroundAccessibilityService::class.java)){
+                    if (!Utilities.isAccessibilityServiceEnabled(requireContext(), BackgroundAccessibilityService::class.java)) {
                         if (!showAlertForPermission(true)) {
-                            backgroundModeToggle.isChecked = false
+                            includeView.firewallBackgroundModeCheck.isChecked = false
                             persistentState.setIsBackgroundEnabled(false)
                         }
                     }
                     GlobalVariable.isBackgroundEnabled = !checkedVal
                     persistentState.setIsBackgroundEnabled(!checkedVal)
-                    backgroundModeToggle.isChecked = !checkedVal
+                    includeView.firewallBackgroundModeCheck.isChecked = !checkedVal
                 } else {
                     if (!showAlertForPermission(false)) {
-                        backgroundModeToggle.isChecked = false
+                        includeView.firewallBackgroundModeCheck.isChecked = false
                         persistentState.setIsBackgroundEnabled(false)
                     }
                 }
             } else {
-                backgroundModeToggle.isChecked = false
+                includeView.firewallBackgroundModeCheck.isChecked = false
+                persistentState.setIsBackgroundEnabled(false)
+            }
+        }
+
+        includeView.firewallBackgroundModeCheck.setOnCheckedChangeListener(null)
+
+        includeView.firewallBackgroundModeCheck.setOnClickListener {
+            val checkedVal = !includeView.firewallBackgroundModeCheck.isChecked
+            if (!checkedVal) {
+                if (Utilities.isAccessibilityServiceEnabledEnhanced(requireContext(), BackgroundAccessibilityService::class.java)) {
+                    if (!Utilities.isAccessibilityServiceEnabled(requireContext(), BackgroundAccessibilityService::class.java)) {
+                        if (!showAlertForPermission(true)) {
+                            includeView.firewallBackgroundModeCheck.isChecked = false
+                            persistentState.setIsBackgroundEnabled(false)
+                        }
+                    }
+                    GlobalVariable.isBackgroundEnabled = !checkedVal
+                    persistentState.setIsBackgroundEnabled(!checkedVal)
+                    includeView.firewallBackgroundModeCheck.isChecked = !checkedVal
+                } else {
+                    if (!showAlertForPermission(false)) {
+                        includeView.firewallBackgroundModeCheck.isChecked = false
+                        persistentState.setIsBackgroundEnabled(false)
+                    }
+                }
+            } else {
+                includeView.firewallBackgroundModeCheck.isChecked = false
                 persistentState.setIsBackgroundEnabled(false)
             }
         }
@@ -279,65 +206,65 @@ class UniversalFirewallFragment : Fragment() , SearchView.OnQueryTextListener {
         val appCount = GlobalVariable.appList.size
         val act: FirewallActivity = requireContext() as FirewallActivity
         appInfoRepository.getWhitelistCountLiveData().observe(act, {
-            whitelistCountTxt.text = "$it/$appCount apps whitelisted."
+            includeView.firewallUnivWhitelistCount.text = "$it/$appCount apps whitelisted."
         })
 
-        whiteListHeader.setOnClickListener{
-            whiteListHeader.isEnabled = false
-            val customDialog = WhitelistAppDialog(requireContext(), appInfoRepository, get(), recyclerAdapter!!,appInfoViewModel)
+        includeView.firewallAppsShowTxt.setOnClickListener {
+            includeView.firewallAppsShowTxt.isEnabled = false
+            val customDialog = WhitelistAppDialog(requireContext(), appInfoRepository, get(), recyclerAdapter!!, appInfoViewModel)
             //if we know that the particular variable not null any time ,we can assign !!
             // (not null operator ), then  it won't check for null, if it becomes null,
             // it will throw exception
             customDialog.show()
             customDialog.setCanceledOnTouchOutside(false)
-            Handler().postDelayed({ whiteListHeader.isEnabled = true }, 100)
+            Handler().postDelayed({ includeView.firewallAppsShowTxt.isEnabled = true }, 100)
         }
 
-        ipRulesHeader.setOnClickListener {
+        includeView.firewallRulesShowTxt.setOnClickListener {
             if (ipListState) {
                 ipListState = false
-                ipSearchViewContainer.visibility = View.VISIBLE
-                recyclerView.visibility = View.VISIBLE
-                ipRulesExpTxt.visibility = View.VISIBLE
-                ipSearchCardContainer.visibility = View.VISIBLE
-                ipRulesNoRulesSetTxt.visibility = View.VISIBLE
-                ipRulesHeader.setCompoundDrawablesWithIntrinsicBounds(null, null, ContextCompat.getDrawable(requireContext(), R.drawable.ic_keyboard_arrow_down_gray_24dp), null)
+                includeView.firewallSearchViewTop.visibility = View.VISIBLE
+                includeView.firewallUniversalRecycler.visibility = View.VISIBLE
+                includeView.firewallUnivWhitelistRulesExpTxt.visibility = View.VISIBLE
+                includeView.firewallSearchContainer.visibility = View.VISIBLE
+                includeView.firewallNoRulesSetTxt.visibility = View.VISIBLE
+                includeView.firewallRulesShowTxt.setCompoundDrawablesWithIntrinsicBounds(null, null, ContextCompat.getDrawable(requireContext(), R.drawable.ic_keyboard_arrow_down_gray_24dp), null)
             } else {
                 ipListState = true
-                ipSearchViewContainer.visibility = View.GONE
-                recyclerView.visibility = View.GONE
-                ipRulesExpTxt.visibility = View.VISIBLE
-                ipRulesNoRulesSetTxt.visibility = View.GONE
-                ipSearchCardContainer.visibility = View.GONE
-                ipRulesHeader.setCompoundDrawablesWithIntrinsicBounds(null, null, ContextCompat.getDrawable(requireContext(), R.drawable.ic_keyboard_arrow_up_gray_24dp), null)
+                includeView.firewallSearchViewTop.visibility = View.GONE
+                includeView.firewallUniversalRecycler.visibility = View.GONE
+                includeView.firewallUnivWhitelistRulesExpTxt.visibility = View.VISIBLE
+                includeView.firewallNoRulesSetTxt.visibility = View.GONE
+                includeView.firewallSearchContainer.visibility = View.GONE
+                includeView.firewallRulesShowTxt.setCompoundDrawablesWithIntrinsicBounds(null, null, ContextCompat.getDrawable(requireContext(), R.drawable.ic_keyboard_arrow_up_gray_24dp), null)
             }
         }
 
-        ipRulesDeleteBtn.setOnClickListener{
+        includeView.firewallSearchDeleteIcon.setOnClickListener {
             showDialogForDelete()
         }
 
-        ipSearchView.setOnQueryTextListener(this)
-        ipSearchView.setOnClickListener {
-            ipSearchView.requestFocus()
-            ipSearchView.onActionViewExpanded()
+        includeView.firewallSearchView.setOnQueryTextListener(this)
+        includeView.firewallSearchView.setOnClickListener {
+            includeView.firewallSearchView.requestFocus()
+            includeView.firewallSearchView.onActionViewExpanded()
         }
 
     }
 
-    private fun setIPRulesVisible(){
+    private fun setIPRulesVisible() {
         ipListState = false
-        ipSearchViewContainer.visibility = View.VISIBLE
-        recyclerView.visibility = View.VISIBLE
-        ipRulesExpTxt.visibility = View.VISIBLE
-        ipSearchCardContainer.visibility = View.VISIBLE
-        ipRulesNoRulesSetTxt.visibility = View.VISIBLE
-        ipRulesHeader.setCompoundDrawablesWithIntrinsicBounds(null, null, ContextCompat.getDrawable(requireContext(), R.drawable.ic_keyboard_arrow_down_gray_24dp), null)
+        b.appScrollingInclFirewall.firewallSearchViewTop.visibility = View.VISIBLE
+        b.appScrollingInclFirewall.firewallUniversalRecycler.visibility = View.VISIBLE
+        b.appScrollingInclFirewall.firewallUnivWhitelistRulesExpTxt.visibility = View.VISIBLE
+        b.appScrollingInclFirewall.firewallSearchContainer.visibility = View.VISIBLE
+        b.appScrollingInclFirewall.firewallNoRulesSetTxt.visibility = View.VISIBLE
+        b.appScrollingInclFirewall.firewallRulesShowTxt.setCompoundDrawablesWithIntrinsicBounds(null, null, ContextCompat.getDrawable(requireContext(), R.drawable.ic_keyboard_arrow_down_gray_24dp), null)
     }
 
     private fun showDialogForDelete() {
         val count = blockedConnectionsRepository.getBlockedConnectionsCount()
-        if(count > 0) {
+        if (count > 0) {
             val builder = AlertDialog.Builder(requireContext())
             //set title for alert dialog
             builder.setTitle(R.string.univ_delete_firewall_dialog_title)
@@ -346,7 +273,7 @@ class UniversalFirewallFragment : Fragment() , SearchView.OnQueryTextListener {
             builder.setIcon(android.R.drawable.ic_dialog_alert)
             builder.setCancelable(true)
             //performing positive action
-            builder.setPositiveButton("Delete all") { dialogInterface, which ->
+            builder.setPositiveButton("Delete all") { _, _ ->
 
                 blockedConnectionsRepository.deleteAllIPRulesUniversal()
                 GlobalVariable.firewallRules.clear()
@@ -354,56 +281,56 @@ class UniversalFirewallFragment : Fragment() , SearchView.OnQueryTextListener {
             }
 
             //performing negative action
-            builder.setNegativeButton("Cancel") { dialogInterface, which ->
+            builder.setNegativeButton("Cancel") { _, _ ->
             }
             // Create the AlertDialog
             val alertDialog: AlertDialog = builder.create()
             // Set other dialog properties
             alertDialog.setCancelable(true)
             alertDialog.show()
-        }else{
-            Utilities.showToastInMidLayout(requireContext(),"No IP rules set",Toast.LENGTH_SHORT)
+        } else {
+            Utilities.showToastInMidLayout(requireContext(), "No IP rules set", Toast.LENGTH_SHORT)
         }
     }
 
     override fun onResume() {
         super.onResume()
-        unknownToggle.isChecked =  persistentState.blockUnknownConnections
+        b.appScrollingInclFirewall.firewallUnknownConnectionModeCheck.isChecked = persistentState.blockUnknownConnections
         if (Utilities.isAccessibilityServiceEnabledEnhanced(requireContext(), BackgroundAccessibilityService::class.java)) {
             if (DEBUG) Log.d(LOG_TAG, "Background - onLoad accessibility is true")
-            backgroundModeToggle.isChecked = persistentState.backgroundEnabled
+            b.appScrollingInclFirewall.firewallBackgroundModeCheck.isChecked = persistentState.backgroundEnabled
         } else {
             if (DEBUG) Log.d(LOG_TAG, "Background - onLoad accessibility is true, changed pref")
             persistentState.setIsBackgroundEnabled(false)
-            backgroundModeToggle.isChecked = false
+            b.appScrollingInclFirewall.firewallBackgroundModeCheck.isChecked = false
         }
     }
 
-    private fun showAlertForPermission(isRegrant : Boolean) : Boolean {
-        var isAllowed  = false
+    private fun showAlertForPermission(isRegrant: Boolean): Boolean {
+        var isAllowed = false
         val builder = AlertDialog.Builder(requireContext())
         //set title for alert dialog
-        if(isRegrant){
+        if (isRegrant) {
             builder.setTitle(R.string.alert_permission_accessibility_regrant)
-        }else {
+        } else {
             builder.setTitle(R.string.alert_permission_accessibility)
         }
         //set message for alert dialog
-        if(isRegrant){
+        if (isRegrant) {
             builder.setMessage(R.string.alert_firewall_accessibility_regrant_explanation)
-        }else{
+        } else {
             builder.setMessage(R.string.alert_firewall_accessibility_explanation)
         }
 
         builder.setIcon(android.R.drawable.ic_dialog_alert)
         //performing positive action
-        builder.setPositiveButton("Grant"){ _, _ ->
+        builder.setPositiveButton("Grant") { _, _ ->
             isAllowed = true
             val intent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
             startActivityForResult(intent, 0)
         }
         //performing negative action
-        builder.setNegativeButton("Deny"){ _, _ ->
+        builder.setNegativeButton("Deny") { _, _ ->
         }
         // Create the AlertDialog
         val alertDialog: AlertDialog = builder.create()

--- a/app/src/main/java/com/celzero/bravedns/ui/UniversalFirewallFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/UniversalFirewallFragment.kt
@@ -76,10 +76,10 @@ class UniversalFirewallFragment : Fragment(R.layout.universal_fragement_containe
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        viewModel.blockedUnivRulesList.observe(viewLifecycleOwner, androidx.lifecycle.Observer(recyclerRulesAdapter!!::submitList))
-        appInfoViewModel.appDetailsList.observe(viewLifecycleOwner, androidx.lifecycle.Observer(recyclerAdapter!!::submitList))
         super.onViewCreated(view, savedInstanceState)
         initView()
+        viewModel.blockedUnivRulesList.observe(viewLifecycleOwner, androidx.lifecycle.Observer(recyclerRulesAdapter!!::submitList))
+        appInfoViewModel.appDetailsList.observe(viewLifecycleOwner, androidx.lifecycle.Observer(recyclerAdapter!!::submitList))
     }
 
     private fun initView() {

--- a/app/src/main/java/com/celzero/bravedns/ui/WelcomeActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/WelcomeActivity.kt
@@ -22,25 +22,21 @@ import android.os.Build
 import android.os.Bundle
 import android.text.Html
 import android.view.*
-import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.viewpager.widget.PagerAdapter
 import androidx.viewpager.widget.ViewPager
 import com.celzero.bravedns.R
+import com.celzero.bravedns.databinding.ActivityWelcomeBinding
 import com.celzero.bravedns.service.PersistentState
 import org.koin.android.ext.android.inject
 
-class WelcomeActivity  : AppCompatActivity() {
+class WelcomeActivity : AppCompatActivity() {
+    private lateinit var b: ActivityWelcomeBinding
+    private lateinit var dots: Array<TextView?>
+    internal val layout: IntArray = intArrayOf(R.layout.welcome_slide1, R.layout.welcome_slide2)
 
-    private lateinit var viewPager : ViewPager
-    private lateinit var dotsLayout: LinearLayout
-    private lateinit var dots : Array<TextView?>
-    internal val layout : IntArray = intArrayOf(R.layout.welcome_slide1,R.layout.welcome_slide2)
-
-    private lateinit var buttonNext : TextView
-    private lateinit var buttonSkip : TextView
-    private lateinit var myPagerAdapter : PagerAdapter
+    private lateinit var myPagerAdapter: PagerAdapter
 
     private val persistentState by inject<PersistentState>()
 
@@ -51,38 +47,30 @@ class WelcomeActivity  : AppCompatActivity() {
             launchHomeScreen()
         }
 
-        setContentView(R.layout.activity_welcome)
-
-
-        viewPager = findViewById(R.id.view_pager)
-        dotsLayout =  findViewById(R.id.layoutDots)
-        buttonSkip = findViewById(R.id.btn_skip)
-        buttonNext =  findViewById(R.id.btn_next)
+        b = ActivityWelcomeBinding.inflate(layoutInflater)
+        setContentView(b.root)
 
         addBottomDots(0)
         changeStatusBarColor()
 
         myPagerAdapter = MyPagerAdapter()
 
-        viewPager.adapter = myPagerAdapter
+        b.viewPager.adapter = myPagerAdapter
 
-        buttonSkip.setOnClickListener {
+        b.btnSkip.setOnClickListener {
             launchHomeScreen()
         }
 
-        buttonNext.setOnClickListener {
+        b.btnNext.setOnClickListener {
             val currentItem = getItem(1)
-            if(currentItem < layout.size)
-                viewPager.setCurrentItem(currentItem)
-            else
-                launchHomeScreen()
+            if (currentItem < layout.size) b.viewPager.currentItem = currentItem
+            else launchHomeScreen()
         }
 
-        viewPager.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
+        b.viewPager.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
             override fun onPageScrollStateChanged(state: Int) {
-                if(ViewPager.SCROLLBAR_POSITION_RIGHT == state+1){
-                    if(getItem(1) == layout.size)
-                        launchHomeScreen()
+                if (ViewPager.SCROLLBAR_POSITION_RIGHT == state + 1) {
+                    if (getItem(1) == layout.size) launchHomeScreen()
                 }
             }
 
@@ -102,31 +90,31 @@ class WelcomeActivity  : AppCompatActivity() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             val window: Window = window
             window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-            window.setStatusBarColor(Color.TRANSPARENT)
+            window.statusBarColor = Color.TRANSPARENT
         }
     }
 
     private fun addBottomDots(currentPage: Int) {
         dots = arrayOfNulls(layout.size)
 
-        val colorActive  = (resources.getIntArray(R.array.array_dot_active))
+        val colorActive = resources.getIntArray(R.array.array_dot_active)
         val colorInActive = resources.getIntArray(R.array.array_dot_inactive)
 
-        dotsLayout.removeAllViews()
-        for(i in dots.indices){
+        b.layoutDots.removeAllViews()
+        for (i in dots.indices) {
             dots[i] = TextView(this)
-            dots[i]?.setText(Html.fromHtml("&#8226;"))
-            dots[i]?.setTextSize(35F)
+            dots[i]?.text = Html.fromHtml("&#8226;")
+            dots[i]?.textSize = 35F
             dots[i]?.setTextColor(colorInActive[currentPage])
-            dotsLayout.addView(dots[i])
+            b.layoutDots.addView(dots[i])
         }
-        if(dots.isNotEmpty()){
+        if (dots.isNotEmpty()) {
             dots[currentPage]?.setTextColor(colorActive[currentPage])
         }
     }
 
-    private fun getItem(i : Int): Int{
-        return viewPager.currentItem+i
+    private fun getItem(i: Int): Int {
+        return b.viewPager.currentItem + i
     }
 
     private fun launchHomeScreen() {
@@ -137,7 +125,7 @@ class WelcomeActivity  : AppCompatActivity() {
 
 
     inner class MyPagerAdapter : PagerAdapter() {
-        private lateinit var layoutInflater : LayoutInflater
+        private lateinit var layoutInflater: LayoutInflater
 
         override fun isViewFromObject(view: View, `object`: Any): Boolean {
             return view == `object`

--- a/app/src/main/java/com/celzero/bravedns/ui/WelcomeActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/WelcomeActivity.kt
@@ -26,13 +26,14 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.viewpager.widget.PagerAdapter
 import androidx.viewpager.widget.ViewPager
+import by.kirich1409.viewbindingdelegate.viewBinding
 import com.celzero.bravedns.R
 import com.celzero.bravedns.databinding.ActivityWelcomeBinding
 import com.celzero.bravedns.service.PersistentState
 import org.koin.android.ext.android.inject
 
-class WelcomeActivity : AppCompatActivity() {
-    private lateinit var b: ActivityWelcomeBinding
+class WelcomeActivity : AppCompatActivity(R.layout.activity_welcome) {
+    private val b by viewBinding(ActivityWelcomeBinding::bind)
     private lateinit var dots: Array<TextView?>
     internal val layout: IntArray = intArrayOf(R.layout.welcome_slide1, R.layout.welcome_slide2)
 
@@ -46,9 +47,6 @@ class WelcomeActivity : AppCompatActivity() {
         if (!persistentState.firstTimeLaunch) {
             launchHomeScreen()
         }
-
-        b = ActivityWelcomeBinding.inflate(layoutInflater)
-        setContentView(b.root)
 
         addBottomDots(0)
         changeStatusBarColor()

--- a/app/src/main/res/layout/bottom_sheet_permission_manager.xml
+++ b/app/src/main/res/layout/bottom_sheet_permission_manager.xml
@@ -7,7 +7,7 @@
     android:paddingBottom="8dp"
     >
     <TextView
-        android:id="@+id/textView"
+        android:id="@+id/txtAutoRemove"
         android:layout_marginTop="8dp"
         android:text="@string/action_automatic"
         android:layout_margin="2dp"
@@ -18,21 +18,21 @@
 
         />
     <TextView
-        android:id="@+id/textView2"
+        android:id="@+id/txtAutoRevoke"
         android:text="@string/action_revoke_only"
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_margin="2dp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView"
+        app:layout_constraintTop_toBottomOf="@+id/txtAutoRemove"
         style="@style/ActionItem"
         />
     <TextView
-        android:id="@+id/textView3"
+        android:id="@+id/txtDoNothing"
         android:text="@string/action_do_nothing"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         android:layout_margin="2dp"
-        app:layout_constraintTop_toBottomOf="@+id/textView2"
+        app:layout_constraintTop_toBottomOf="@+id/txtAutoRevoke"
         style="@style/ActionItem"
         />
    <!-- <TextView


### PR DESCRIPTION
The 'kotlin-android-extensions' Gradle plugin is deprecated so we should migrate to viewBinding + code cleanup along the way.

What this PR is about:

- Replaced almost all findViewById, kotlin.synthetics usage with viewBinding resulting in a net LoC change of -600

- UI code is now type and null safe thanks to viewBinding

- Removed onCreate's setContentView and avoided writing binding boilerplate using by viewBinding delegates(on destroy view is also handled by this delegate in fragments) and Activity/Fragment constructor which accepts R.layout

-  Removed kotlin-android-extensions(includes kotlin.synthetics) which is deperecated

- Every file touched is now formatted using official kotlin code style

- Every file touched have Android Studio's automatic code cleanup applied

- Other minor cleanups done manually

Future improvements:

- Simplifying xml ids now that we are using viewBinding

- Replace remaining findViewById usage in adapters, dialogs, etc