### PR TITLE
v53h: Local blocklist fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ android {
         applicationId "com.celzero.bravedns"
         minSdkVersion 23
         targetSdkVersion 30
-        versionCode 18 // For version name 053g
-        versionName "053g"
+        versionCode 19 // For version name 053h
+        versionName "053h"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/celzero/bravedns/download/AppDownloadManager.kt
+++ b/app/src/main/java/com/celzero/bravedns/download/AppDownloadManager.kt
@@ -107,7 +107,7 @@ class AppDownloadManager(private val context: Context) {
      */
     private fun purge(context: Context, timestamp: Long) {
         downloadIds = LongArray(ONDEVICE_BLOCKLISTS.count())
-        BlocklistDownloadHelper.deleteOldFiles(context, timestamp)
+        BlocklistDownloadHelper.deleteFromExternalDir(context, timestamp)
     }
 
     private fun enqueueDownload(url: String, fileName: String, timestamp: String): Long {

--- a/app/src/main/java/com/celzero/bravedns/download/BlocklistDownloadHelper.kt
+++ b/app/src/main/java/com/celzero/bravedns/download/BlocklistDownloadHelper.kt
@@ -21,6 +21,7 @@ import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
 import com.celzero.bravedns.util.Constants
 import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_DOWNLOAD
 import com.celzero.bravedns.util.Utilities.Companion.deleteRecursive
+import com.celzero.bravedns.util.Utilities.Companion.deleteUnwantedLocalBlocklistFolders
 import java.io.File
 
 class BlocklistDownloadHelper {
@@ -64,8 +65,8 @@ class BlocklistDownloadHelper {
         }
 
         fun deleteFromCanonicalPath(context: Context, timestamp: Long) {
-            val canonicalPath = File("${context.filesDir.canonicalPath}${File.separator}$timestamp")
-            deleteRecursive(canonicalPath)
+            val canonicalPath = File(context.filesDir.canonicalPath + File.separator)
+            deleteUnwantedLocalBlocklistFolders(canonicalPath, timestamp.toString())
         }
 
         fun getExternalFilePath(context: Context, timestamp: String): String {

--- a/app/src/main/java/com/celzero/bravedns/download/BlocklistDownloadHelper.kt
+++ b/app/src/main/java/com/celzero/bravedns/download/BlocklistDownloadHelper.kt
@@ -20,7 +20,7 @@ import android.util.Log
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
 import com.celzero.bravedns.util.Constants
 import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_DOWNLOAD
-import com.celzero.bravedns.util.Utilities.Companion.cleanupOldLocalBlocklistFolders
+import com.celzero.bravedns.util.Utilities.Companion.cleanupOldLocalBlocklistFiles
 import com.celzero.bravedns.util.Utilities.Companion.deleteRecursive
 import java.io.File
 
@@ -56,7 +56,7 @@ class BlocklistDownloadHelper {
          * Now in v053 we are moving the files from external dir to canonical path.
          * So deleting the old files in the external directory.
          */
-        fun deleteOldFiles(context: Context, timestamp: Long) {
+        fun deleteFromExternalDir(context: Context, timestamp: Long) {
             val dir = File(context.getExternalFilesDir(
                 null).toString() + Constants.ONDEVICE_BLOCKLIST_DOWNLOAD_PATH + timestamp)
             if (DEBUG) Log.d(LOG_TAG_DOWNLOAD,
@@ -66,7 +66,7 @@ class BlocklistDownloadHelper {
 
         fun deleteFromCanonicalPath(context: Context, timestamp: Long) {
             val canonicalPath = File(context.filesDir.canonicalPath + File.separator)
-            cleanupOldLocalBlocklistFolders(canonicalPath, timestamp.toString())
+            cleanupOldLocalBlocklistFiles(canonicalPath, timestamp.toString())
         }
 
         fun getExternalFilePath(context: Context, timestamp: String): String {

--- a/app/src/main/java/com/celzero/bravedns/download/BlocklistDownloadHelper.kt
+++ b/app/src/main/java/com/celzero/bravedns/download/BlocklistDownloadHelper.kt
@@ -20,8 +20,8 @@ import android.util.Log
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
 import com.celzero.bravedns.util.Constants
 import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_DOWNLOAD
+import com.celzero.bravedns.util.Utilities.Companion.cleanupOldLocalBlocklistFolders
 import com.celzero.bravedns.util.Utilities.Companion.deleteRecursive
-import com.celzero.bravedns.util.Utilities.Companion.deleteUnwantedLocalBlocklistFolders
 import java.io.File
 
 class BlocklistDownloadHelper {
@@ -66,7 +66,7 @@ class BlocklistDownloadHelper {
 
         fun deleteFromCanonicalPath(context: Context, timestamp: Long) {
             val canonicalPath = File(context.filesDir.canonicalPath + File.separator)
-            deleteUnwantedLocalBlocklistFolders(canonicalPath, timestamp.toString())
+            cleanupOldLocalBlocklistFolders(canonicalPath, timestamp.toString())
         }
 
         fun getExternalFilePath(context: Context, timestamp: String): String {

--- a/app/src/main/java/com/celzero/bravedns/download/FileHandleWorker.kt
+++ b/app/src/main/java/com/celzero/bravedns/download/FileHandleWorker.kt
@@ -97,9 +97,17 @@ class FileHandleWorker(val context: Context, workerParameters: WorkerParameters)
                 return false
             }
 
+            // In case of failure, all files in
+            // 1. "from" dir will be deleted by deleteFromExternalDir
+            // 2. "to" dir will be delete by deleteFromCanonicalPath
+            // during the next download downloadLocalBlocklist
             for (i in children.indices) {
                 val from = dir.absolutePath + File.separator + children[i]
-                val to = localBlocklistDownloadPath(context, children[i], timestamp) ?: return false
+                val to = localBlocklistDownloadPath(context, children[i], timestamp)
+                if (to == null) {
+                    Log.w(LOG_TAG_DOWNLOAD, "Copy failed from $from, to: $to")
+                    return false
+                }
                 val result = Utilities.copy(from, to)
 
                 if (!result) {

--- a/app/src/main/java/com/celzero/bravedns/download/FileHandleWorker.kt
+++ b/app/src/main/java/com/celzero/bravedns/download/FileHandleWorker.kt
@@ -20,6 +20,7 @@ import android.util.Log
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import com.celzero.bravedns.download.BlocklistDownloadHelper.Companion.deleteFromExternalDir
 import com.celzero.bravedns.service.PersistentState
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
 import com.celzero.bravedns.util.Constants
@@ -117,6 +118,7 @@ class FileHandleWorker(val context: Context, workerParameters: WorkerParameters)
             }
 
             updatePersistenceOnCopySuccess(timestamp)
+            deleteFromExternalDir(context, timestamp)
             return true
 
         } catch (e: Exception) {

--- a/app/src/main/java/com/celzero/bravedns/download/FileHandleWorker.kt
+++ b/app/src/main/java/com/celzero/bravedns/download/FileHandleWorker.kt
@@ -98,7 +98,7 @@ class FileHandleWorker(val context: Context, workerParameters: WorkerParameters)
 
             for (i in children.indices) {
                 val from = dir.absolutePath + File.separator + children[i]
-                val to = localBlocklistDownloadPath(context, children[i], timestamp)
+                val to = localBlocklistDownloadPath(context, children[i], timestamp) ?: return false
                 val result = Utilities.copy(from, to)
 
                 if (!result) {

--- a/app/src/main/java/com/celzero/bravedns/net/go/GoVpnAdapter.kt
+++ b/app/src/main/java/com/celzero/bravedns/net/go/GoVpnAdapter.kt
@@ -449,9 +449,9 @@ class GoVpnAdapter(private val context: Context, private val externalScope: Coro
             // Set local blocklist enabled to false and reset the timestamp
             // if there is a failure creating bravedns
             persistentState.blocklistEnabled = false
-            // when the local blocklist is either deleted by an external source or
-            // corrupted, in that case, reset the persistent state (this will disable
-            // local blocklist), next time enabling will prompt the user to download the blocklist
+            // this exception may occur when the local blocklist files are either missing
+            // or corrupted. Reset local blocklist timestamp to make sure
+            // user is prompted to download blocklists again on the next try
             persistentState.localBlocklistTimestamp = 0
             null
         }

--- a/app/src/main/java/com/celzero/bravedns/net/go/GoVpnAdapter.kt
+++ b/app/src/main/java/com/celzero/bravedns/net/go/GoVpnAdapter.kt
@@ -449,8 +449,8 @@ class GoVpnAdapter(private val context: Context, private val externalScope: Coro
             // Set local blocklist enabled to false and reset the timestamp
             // if there is a failure creating bravedns
             persistentState.blocklistEnabled = false
-            // Case: when the local blocklist is either deleted by an external source or
-            // corrupted, in this case, reset the persistent state (this will disable
+            // when the local blocklist is either deleted by an external source or
+            // corrupted, in that case, reset the persistent state (this will disable
             // local blocklist), next time enabling will prompt the user to download the blocklist
             persistentState.localBlocklistTimestamp = 0
             null

--- a/app/src/main/java/com/celzero/bravedns/net/go/GoVpnAdapter.kt
+++ b/app/src/main/java/com/celzero/bravedns/net/go/GoVpnAdapter.kt
@@ -448,6 +448,8 @@ class GoVpnAdapter(private val context: Context, private val externalScope: Coro
             Log.e(LOG_TAG_VPN, "Local brave dns set exception :${e.message}", e)
             // Set local blocklist enabled to false if there is a failure creating bravedns
             persistentState.blocklistEnabled = false
+            // reset the local blocklist timestamp to 0
+            persistentState.localBlocklistTimestamp = 0
             null
         }
     }

--- a/app/src/main/java/com/celzero/bravedns/net/go/GoVpnAdapter.kt
+++ b/app/src/main/java/com/celzero/bravedns/net/go/GoVpnAdapter.kt
@@ -446,9 +446,12 @@ class GoVpnAdapter(private val context: Context, private val externalScope: Coro
                                   path + ONDEVICE_BLOCKLIST_FILE_TAG)
         } catch (e: Exception) {
             Log.e(LOG_TAG_VPN, "Local brave dns set exception :${e.message}", e)
-            // Set local blocklist enabled to false if there is a failure creating bravedns
+            // Set local blocklist enabled to false and reset the timestamp
+            // if there is a failure creating bravedns
             persistentState.blocklistEnabled = false
-            // reset the local blocklist timestamp to 0
+            // Case: when the local blocklist is either deleted by an external source or
+            // corrupted, in this case, reset the persistent state (this will disable
+            // local blocklist), next time enabling will prompt the user to download the blocklist
             persistentState.localBlocklistTimestamp = 0
             null
         }

--- a/app/src/main/java/com/celzero/bravedns/ui/DNSConfigureWebViewActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/DNSConfigureWebViewActivity.kt
@@ -50,9 +50,8 @@ import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_VPN
 import com.celzero.bravedns.util.Themes
 import com.celzero.bravedns.util.Themes.Companion.getCurrentTheme
 import com.celzero.bravedns.util.Utilities
-import com.celzero.bravedns.util.Utilities.Companion.cleanupOldRemoteBlocklistFiles
-import com.celzero.bravedns.util.Utilities.Companion.deleteRecursive
-import com.celzero.bravedns.util.Utilities.Companion.hasRemoteBlocklistDir
+import com.celzero.bravedns.util.Utilities.Companion.cleanupRemoteBlocklistDir
+import com.celzero.bravedns.util.Utilities.Companion.hasRemoteBlocklistFile
 import com.celzero.bravedns.util.Utilities.Companion.isAtleastO
 import com.celzero.bravedns.util.Utilities.Companion.remoteBlocklistDir
 import kotlinx.coroutines.Dispatchers
@@ -428,10 +427,10 @@ class DNSConfigureWebViewActivity : AppCompatActivity(R.layout.activity_faq_webv
 
             val t = parseLong(timestamp)
 
-            if (persistentState.remoteBlocklistTimestamp >= t && hasRemoteBlocklistDir(applicationContext, BLOCKLIST_REMOTE_FOLDER_NAME, t)) return
+            if (hasRemoteBlocklistFile(applicationContext, BLOCKLIST_REMOTE_FOLDER_NAME, t)) return
 
             try {
-                cleanupOldRemoteBlocklistFiles(applicationContext, BLOCKLIST_REMOTE_FOLDER_NAME)
+                cleanupRemoteBlocklistDir(applicationContext, BLOCKLIST_REMOTE_FOLDER_NAME)
                 val filetag = makeFile(t) ?: return
 
                 filetag.writeText(fileContent)

--- a/app/src/main/java/com/celzero/bravedns/ui/DNSConfigureWebViewActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/DNSConfigureWebViewActivity.kt
@@ -50,6 +50,9 @@ import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_VPN
 import com.celzero.bravedns.util.Themes
 import com.celzero.bravedns.util.Themes.Companion.getCurrentTheme
 import com.celzero.bravedns.util.Utilities
+import com.celzero.bravedns.util.Utilities.Companion.cleanupOldRemoteBlocklistFiles
+import com.celzero.bravedns.util.Utilities.Companion.deleteRecursive
+import com.celzero.bravedns.util.Utilities.Companion.hasRemoteBlocklistDir
 import com.celzero.bravedns.util.Utilities.Companion.isAtleastO
 import com.celzero.bravedns.util.Utilities.Companion.remoteBlocklistDir
 import kotlinx.coroutines.Dispatchers
@@ -425,9 +428,10 @@ class DNSConfigureWebViewActivity : AppCompatActivity(R.layout.activity_faq_webv
 
             val t = parseLong(timestamp)
 
-            if (persistentState.remoteBlocklistTimestamp >= t) return
+            if (persistentState.remoteBlocklistTimestamp >= t && hasRemoteBlocklistDir(applicationContext, BLOCKLIST_REMOTE_FOLDER_NAME, t)) return
 
             try {
+                cleanupOldRemoteBlocklistFiles(applicationContext, BLOCKLIST_REMOTE_FOLDER_NAME)
                 val filetag = makeFile(t) ?: return
 
                 filetag.writeText(fileContent)

--- a/app/src/main/java/com/celzero/bravedns/ui/HomeScreenActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/HomeScreenActivity.kt
@@ -44,6 +44,7 @@ import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_APP_UPDATE
 import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_DOWNLOAD
 import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_UI
 import com.celzero.bravedns.util.Themes.Companion.getCurrentTheme
+import com.celzero.bravedns.util.Utilities.Companion.deleteUnwantedLocalBlocklistFolders
 import com.celzero.bravedns.util.Utilities.Companion.getPackageMetadata
 import com.celzero.bravedns.util.Utilities.Companion.isPlayStoreFlavour
 import com.celzero.bravedns.util.Utilities.Companion.isWebsiteFlavour
@@ -52,6 +53,7 @@ import kotlinx.coroutines.*
 import okhttp3.*
 import org.koin.android.ext.android.get
 import org.koin.android.ext.android.inject
+import java.io.File
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -128,7 +130,8 @@ class HomeScreenActivity : AppCompatActivity(R.layout.activity_home_screen) {
         persistentState.numberOfRequests = persistentState.oldNumberRequests.toLong()
         persistentState.numberOfBlockedRequests = persistentState.oldBlockedRequests.toLong()
         io {
-            refreshDatabase.refreshAppInfoDatabase()
+            val localBlocklistFolder = File(this.filesDir.canonicalPath + File.separator)
+            deleteUnwantedLocalBlocklistFolders(localBlocklistFolder, persistentState.localBlocklistTimestamp.toString())
         }
     }
 
@@ -162,9 +165,10 @@ class HomeScreenActivity : AppCompatActivity(R.layout.activity_home_screen) {
         persistentState.appVersion = version
         persistentState.showWhatsNewChip = true
 
-        // FIXME: remove this post v053g
-        // this is to fix the persistence state which was saved as Int instead of Long.
-        // Modification of persistence state
+        // FIXME: remove this post v054
+        // this is to fix the pile up of local blocklist folders in app's canonical path
+        // deletes all the folder names starting with "16" other than current local blocklist
+        // timestamp
         removeThisMethod()
     }
 

--- a/app/src/main/java/com/celzero/bravedns/ui/HomeScreenActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/HomeScreenActivity.kt
@@ -44,7 +44,7 @@ import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_APP_UPDATE
 import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_DOWNLOAD
 import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_UI
 import com.celzero.bravedns.util.Themes.Companion.getCurrentTheme
-import com.celzero.bravedns.util.Utilities.Companion.deleteUnwantedLocalBlocklistFolders
+import com.celzero.bravedns.util.Utilities.Companion.cleanupOldLocalBlocklistFolders
 import com.celzero.bravedns.util.Utilities.Companion.getPackageMetadata
 import com.celzero.bravedns.util.Utilities.Companion.isPlayStoreFlavour
 import com.celzero.bravedns.util.Utilities.Companion.isWebsiteFlavour
@@ -131,7 +131,7 @@ class HomeScreenActivity : AppCompatActivity(R.layout.activity_home_screen) {
         persistentState.numberOfBlockedRequests = persistentState.oldBlockedRequests.toLong()
         io {
             val localBlocklistFolder = File(this.filesDir.canonicalPath + File.separator)
-            deleteUnwantedLocalBlocklistFolders(localBlocklistFolder, persistentState.localBlocklistTimestamp.toString())
+            cleanupOldLocalBlocklistFolders(localBlocklistFolder, persistentState.localBlocklistTimestamp.toString())
         }
     }
 

--- a/app/src/main/java/com/celzero/bravedns/ui/HomeScreenActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/HomeScreenActivity.kt
@@ -44,7 +44,8 @@ import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_APP_UPDATE
 import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_DOWNLOAD
 import com.celzero.bravedns.util.LoggerConstants.Companion.LOG_TAG_UI
 import com.celzero.bravedns.util.Themes.Companion.getCurrentTheme
-import com.celzero.bravedns.util.Utilities.Companion.cleanupOldLocalBlocklistFolders
+import com.celzero.bravedns.util.Utilities.Companion.cleanupOldLocalBlocklistFiles
+import com.celzero.bravedns.util.Utilities.Companion.deleteRecursive
 import com.celzero.bravedns.util.Utilities.Companion.getPackageMetadata
 import com.celzero.bravedns.util.Utilities.Companion.isPlayStoreFlavour
 import com.celzero.bravedns.util.Utilities.Companion.isWebsiteFlavour
@@ -127,11 +128,12 @@ class HomeScreenActivity : AppCompatActivity(R.layout.activity_home_screen) {
     }
 
     private fun removeThisMethod() {
-        persistentState.numberOfRequests = persistentState.oldNumberRequests.toLong()
-        persistentState.numberOfBlockedRequests = persistentState.oldBlockedRequests.toLong()
         io {
-            val localBlocklistFolder = File(this.filesDir.canonicalPath + File.separator)
-            cleanupOldLocalBlocklistFolders(localBlocklistFolder, persistentState.localBlocklistTimestamp.toString())
+            val canonicalDir = File(this.filesDir.canonicalPath + File.separator)
+            cleanupOldLocalBlocklistFiles(canonicalDir, persistentState.localBlocklistTimestamp.toString())
+            // clean up files in external files dir
+            val externalDir = File(this.getExternalFilesDir(null).toString() + Constants.ONDEVICE_BLOCKLIST_DOWNLOAD_PATH)
+            deleteRecursive(externalDir)
         }
     }
 

--- a/app/src/main/java/com/celzero/bravedns/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/SettingsFragment.kt
@@ -436,7 +436,12 @@ class SettingsFragment : Fragment(R.layout.activity_settings_screen) {
         }
 
         b.settingsActivityOnDeviceBlockRefreshBtn.setOnClickListener {
-            updateBlocklistIfNeeded(isRefresh = true)
+            // Update check should not be carried when vpn in lockdown mode
+            if (VpnController.isVpnLockdown()) {
+                showVpnLockdownDownloadDialog()
+            } else {
+                updateBlocklistIfNeeded(isRefresh = true)
+            }
         }
 
         val workManager = WorkManager.getInstance(requireContext().applicationContext)

--- a/app/src/main/java/com/celzero/bravedns/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/SettingsFragment.kt
@@ -414,9 +414,7 @@ class SettingsFragment : Fragment(R.layout.activity_settings_screen) {
                             persistentState.numberOfLocalBlocklists.toString())
                     } else {
                         b.settingsActivityOnDeviceBlockSwitch.isChecked = false
-                        if (VpnController.isVpnLockdown()) {
-                            showVpnLockdownDownloadDialog()
-                        } else {
+                        initiateLocalBlocklistDownload {
                             showDownloadDialog()
                         }
                     }
@@ -436,10 +434,7 @@ class SettingsFragment : Fragment(R.layout.activity_settings_screen) {
         }
 
         b.settingsActivityOnDeviceBlockRefreshBtn.setOnClickListener {
-            // Update check should not be carried when vpn in lockdown mode
-            if (VpnController.isVpnLockdown()) {
-                showVpnLockdownDownloadDialog()
-            } else {
+            initiateLocalBlocklistDownload {
                 updateBlocklistIfNeeded(isRefresh = true)
             }
         }
@@ -477,6 +472,18 @@ class SettingsFragment : Fragment(R.layout.activity_settings_screen) {
                     // no-op
                 }
             })
+    }
+
+    // As of now, the android download manager is used to download blocklist files.
+    // When VPN is in lockdown mode, downloads are not succeeding. As an interim fix,
+    // prompt dialog to the user about lockdown mode. No need for the below case if
+    // local blocklists download is carried away by the in-built download manager.
+    private fun initiateLocalBlocklistDownload(f: () -> Unit) {
+        if (VpnController.isVpnLockdown()) {
+            showVpnLockdownDownloadDialog()
+        } else {
+            f()
+        }
     }
 
     private fun refreshOnDeviceBlocklistUi() {

--- a/app/src/main/java/com/celzero/bravedns/ui/SettingsFragment.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/SettingsFragment.kt
@@ -554,7 +554,7 @@ class SettingsFragment : Fragment(R.layout.activity_settings_screen) {
                 val json = JSONObject(stringResponse)
                 val version = json.optInt(Constants.JSON_VERSION, 0)
                 if (DEBUG) Log.d(LOG_TAG_DOWNLOAD,
-                                 "client onResponse for refresh blocklist files-  $version")
+                                 "client onResponse for refresh blocklist files:  $version")
                 if (version != Constants.UPDATE_CHECK_RESPONSE_VERSION) {
                     return
                 }
@@ -562,7 +562,7 @@ class SettingsFragment : Fragment(R.layout.activity_settings_screen) {
                 val shouldUpdate = json.optBoolean(Constants.JSON_UPDATE, false)
                 val timestamp = json.optLong(Constants.JSON_LATEST, Constants.INIT_TIME_MS)
                 if (DEBUG) Log.d(LOG_TAG_DOWNLOAD, "onResponse:  update? $shouldUpdate")
-                if (shouldUpdate) {
+                if (shouldUpdate || !hasLocalBlocklists(activity?.applicationContext, timestamp)) {
                     appDownloadManager.downloadLocalBlocklist(timestamp)
                     return
                 }

--- a/app/src/main/java/com/celzero/bravedns/util/Utilities.kt
+++ b/app/src/main/java/com/celzero/bravedns/util/Utilities.kt
@@ -513,10 +513,10 @@ class Utilities {
         fun cleanupOldLocalBlocklistFiles(fileOrDir: File, activeDir: String) {
             if (fileOrDir.name.equals(activeDir)) return
 
-            // local blocklist dirs are created with timestamp value.
-            // folders with timestamp other than current local blocklist timestamp
-            // will be deleted (path: ../files/<timestamp>).
-            // below check for file name starts with "16" will delete only those files.
+            // local blocklist dirs are named with timestamps, ex: 1635754946983
+            // Dirs other than activeDir (current timestamp)
+            // should be deleted (path: ../files/<timestamp>).
+            // delete both files and dirs starting with "16".
             if (fileOrDir.name.startsWith("16")) {
                 deleteRecursive(fileOrDir)
                 return
@@ -526,7 +526,7 @@ class Utilities {
                 fileOrDir.listFiles()?.forEach { child ->
                     cleanupOldLocalBlocklistFiles(child, activeDir)
                 }
-            }
+            } // ignore files that don't start with "16"
         }
 
         fun hasLocalBlocklists(ctx: Context?, timestamp: Long): Boolean {

--- a/app/src/main/java/com/celzero/bravedns/util/Utilities.kt
+++ b/app/src/main/java/com/celzero/bravedns/util/Utilities.kt
@@ -519,6 +519,7 @@ class Utilities {
             // below check for file name starts with "16" will delete only those files.
             if (fileOrDir.name.startsWith("16")) {
                 deleteRecursive(fileOrDir)
+                return
             }
 
             if (fileOrDir.isDirectory) {
@@ -556,7 +557,7 @@ class Utilities {
         fun cleanupRemoteBlocklistDir(ctx: Context?, which: String) {
             ctx ?: return
 
-            val dir = File(ctx.filesDir.canonicalPath + File.separator + which)
+            val dir = File(remoteBlocklistDownloadBasePath(ctx, which))
             deleteRecursive(dir)
         }
 
@@ -564,16 +565,15 @@ class Utilities {
             if (ctx == null) return null
 
             return try {
-                File(remoteBlocklistDownloadBasePath(ctx, which, timestamp))
+                File(remoteBlocklistDownloadBasePath(ctx, which) + File.separator + timestamp)
             } catch (e: IOException) {
                 Log.e(LOG_TAG_VPN, "Could not fetch remote blocklist: " + e.message, e)
                 null
             }
         }
 
-        private fun remoteBlocklistDownloadBasePath(ctx: Context, which: String,
-                                                    timestamp: Long): String {
-            return ctx.filesDir.canonicalPath + File.separator + which + File.separator + timestamp
+        private fun remoteBlocklistDownloadBasePath(ctx: Context, which: String): String {
+            return ctx.filesDir.canonicalPath + File.separator + which
         }
 
         fun remoteBlocklistFile(dirPath: String, fileName: String): File? {

--- a/app/src/main/java/com/celzero/bravedns/util/Utilities.kt
+++ b/app/src/main/java/com/celzero/bravedns/util/Utilities.kt
@@ -48,7 +48,6 @@ import com.celzero.bravedns.R
 import com.celzero.bravedns.database.AppInfoRepository.Companion.NO_PACKAGE
 import com.celzero.bravedns.net.doh.CountryMap
 import com.celzero.bravedns.service.BraveVPNService
-import com.celzero.bravedns.ui.DNSConfigureWebViewActivity
 import com.celzero.bravedns.ui.HomeScreenActivity.GlobalVariable.DEBUG
 import com.celzero.bravedns.ui.PauseActivity
 import com.celzero.bravedns.util.Constants.Companion.ACTION_VPN_SETTINGS_INTENT
@@ -511,18 +510,19 @@ class Utilities {
             return ctx.filesDir.canonicalPath + File.separator + timestamp + File.separator + which
         }
 
-        fun cleanupOldLocalBlocklistFolders(fileOrDirectory: File,
-                                            currentActiveFolder: String) {
-            if (fileOrDirectory.name.equals(currentActiveFolder)) return
+        fun cleanupOldLocalBlocklistFiles(fileOrDir: File, activeDir: String) {
+            if (fileOrDir.name.equals(activeDir)) return
 
-            if (fileOrDirectory.name.startsWith("16")) {
-                deleteRecursive(fileOrDirectory)
+            // local blocklist dirs are created with timestamp value.
+            // below check for file name starts with "16" will delete only those files.
+            if (fileOrDir.name.startsWith("16")) {
+                deleteRecursive(fileOrDir)
             }
             // folders with timestamp other than current local blocklist timestamp
             // will be deleted (path: ../files/<timestamp>)
-            if (fileOrDirectory.isDirectory) {
-                fileOrDirectory.listFiles()?.forEach { child ->
-                    cleanupOldLocalBlocklistFolders(child, currentActiveFolder)
+            if (fileOrDir.isDirectory) {
+                fileOrDir.listFiles()?.forEach { child ->
+                    cleanupOldLocalBlocklistFiles(child, activeDir)
                 }
             }
         }
@@ -545,18 +545,14 @@ class Utilities {
             }
         }
 
-        fun hasRemoteBlocklistDir(ctx: Context?, which: String, timestamp: Long): Boolean {
+        fun hasRemoteBlocklistFile(ctx: Context?, which: String, timestamp: Long): Boolean {
             val remoteDir = remoteBlocklistDir(ctx, which, timestamp) ?: return false
             val remoteFile = remoteBlocklistFile(remoteDir.absolutePath,
                                                  Constants.ONDEVICE_BLOCKLIST_FILE_TAG) ?: return false
-            if (remoteFile.exists()) {
-                return true
-            }
-
-            return false
+            return remoteFile.exists()
         }
 
-        fun cleanupOldRemoteBlocklistFiles(ctx: Context?, which: String) {
+        fun cleanupRemoteBlocklistDir(ctx: Context?, which: String) {
             ctx ?: return
 
             val dir = File(ctx.filesDir.canonicalPath + File.separator + which)

--- a/app/src/main/java/com/celzero/bravedns/util/Utilities.kt
+++ b/app/src/main/java/com/celzero/bravedns/util/Utilities.kt
@@ -508,6 +508,23 @@ class Utilities {
             return ctx.filesDir.canonicalPath + File.separator + timestamp + File.separator + which
         }
 
+        fun deleteUnwantedLocalBlocklistFolders(fileOrDirectory: File,
+                                                currentActiveFolder: String) {
+            // folders with timestamp other than current local blocklist timestamp
+            // will be deleted (path: ../files/<timestamp>)
+            if (fileOrDirectory.isDirectory) {
+                fileOrDirectory.listFiles()?.forEach { child ->
+                    deleteUnwantedLocalBlocklistFolders(child, currentActiveFolder)
+                }
+            }
+
+            if (fileOrDirectory.name.startsWith("16") && !fileOrDirectory.name.equals(
+                    currentActiveFolder)) {
+                deleteRecursive(fileOrDirectory)
+            }
+
+        }
+
         fun hasLocalBlocklists(ctx: Context, timestamp: Long): Boolean {
             val a = Constants.ONDEVICE_BLOCKLISTS.all {
                 localBlocklistFile(ctx, it.filename, timestamp)?.exists() == true

--- a/app/src/main/java/com/celzero/bravedns/util/Utilities.kt
+++ b/app/src/main/java/com/celzero/bravedns/util/Utilities.kt
@@ -514,12 +514,13 @@ class Utilities {
             if (fileOrDir.name.equals(activeDir)) return
 
             // local blocklist dirs are created with timestamp value.
+            // folders with timestamp other than current local blocklist timestamp
+            // will be deleted (path: ../files/<timestamp>).
             // below check for file name starts with "16" will delete only those files.
             if (fileOrDir.name.startsWith("16")) {
                 deleteRecursive(fileOrDir)
             }
-            // folders with timestamp other than current local blocklist timestamp
-            // will be deleted (path: ../files/<timestamp>)
+
             if (fileOrDir.isDirectory) {
                 fileOrDir.listFiles()?.forEach { child ->
                     cleanupOldLocalBlocklistFiles(child, activeDir)


### PR DESCRIPTION
Fix to clear the unwanted or old local blocklist files.

Old local blocklist files are not cleared from the
canonical path of the application which resulted
in increase of app size.

Now the files are cleared, only the current local
blocklist files will be retained.