### PR TITLE
runtime object check issue fix

### DIFF
--- a/app/src/main/java/com/celzero/bravedns/database/RethinkLocalFileTag.kt
+++ b/app/src/main/java/com/celzero/bravedns/database/RethinkLocalFileTag.kt
@@ -89,25 +89,25 @@ class RethinkLocalFileTag {
                 "group" -> group = it.value as String
                 "subg" -> subg = it.value as String
                 "url" -> {
-                    if (it.value is String) {
+                    if (it.value as Any? is String) {
                         url = listOf(it.value as String)
-                    } else if (it.value is List<*>) {
+                    } else if (it.value as Any? is List<*>) {
                         url = it.value as List<String>
                     }
                 }
                 "show" -> show = it.value as Int
                 "entries" -> entries = it.value as Int
                 "pack" -> {
-                    if (it.value is String) {
+                    if (it.value as Any? is String) {
                         pack = listOf(it.value as String)
-                    } else if (it.value is List<*>) {
+                    } else if (it.value as Any? is List<*>) {
                         pack = it.value as List<String>
                     }
                 }
                 "simpleTagId" -> simpleTagId = it.value as Int
                 "isSelected" -> {
                     isSelected =
-                        if (it.value is Boolean) {
+                        if (it.value as Any? is Boolean) {
                             it.value as Boolean
                         } else {
                             (it.value as Int) == 1

--- a/app/src/main/java/com/celzero/bravedns/service/RethinkBlocklistManager.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/RethinkBlocklistManager.kt
@@ -359,7 +359,7 @@ object RethinkBlocklistManager : KoinComponent {
             // only add the tag if it is not already present
             selectedTags.add(localFileTags.value)
         } else {
-            return 0
+            // no-op
         }
 
         val stamp = getStamp(context, selectedTags, RethinkBlocklistType.LOCAL)


### PR DESCRIPTION
In our case, the compiler knows this object type. The code receives the object from a content provider.

To fix this, cast the received object to the Any? type and then perform a type check against the declared variable type. By doing this, the code can verify that the object is of the expected type before using it.