### PR TITLE
Fix BraveTileService

### DIFF
--- a/app/src/full/java/com/celzero/bravedns/ui/HomeScreenFragment.kt
+++ b/app/src/full/java/com/celzero/bravedns/ui/HomeScreenFragment.kt
@@ -820,7 +820,6 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
     override fun onResume() {
         super.onResume()
         handleShimmer()
-        maybeAutoStart()
         updateCardsUi()
         syncDnsStatus()
         handleQuickSettingsChips()
@@ -1047,20 +1046,6 @@ class HomeScreenFragment : Fragment(R.layout.fragment_home_screen) {
                         .show()
                 }
             }
-    }
-
-    /**
-     * Issue fix - https://github.com/celzero/rethink-app/issues/57 When the application
-     * crashes/updates it goes into red waiting state. This causes confusion to the users also
-     * requires click of START button twice to start the app. FIX : The check for the controller
-     * state. If persistence state has vpn enabled and the VPN is not connected then the start will
-     * be initiated.
-     */
-    private fun maybeAutoStart() {
-        if (isVpnActivated && !VpnController.state().on) {
-            Log.i(LOG_TAG_VPN, "start VPN (previous state)")
-            prepareAndStartVpn()
-        }
     }
 
     // Sets the UI DNS status on/off.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,7 +64,7 @@
             </intent-filter>
 
             <meta-data
-                android:name="android.service.quicksettings.ACTIVE_TILE"
+                android:name="android.service.quicksettings.TOGGLEABLE_TILE"
                 android:value="true" />
         </service>
 

--- a/app/src/main/java/com/celzero/bravedns/service/VpnController.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/VpnController.kt
@@ -39,7 +39,7 @@ object VpnController : KoinComponent {
 
     private var braveVpnService: BraveVPNService? = null
     private var connectionState: BraveVPNService.State? = null
-    private val persistentState by inject<PersistentState>()
+    val persistentState by inject<PersistentState>()
     private var states: Channel<BraveVPNService.State?>? = null
     var controllerScope: CoroutineScope? = null
         private set

--- a/app/src/main/java/com/celzero/bravedns/service/VpnController.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/VpnController.kt
@@ -138,6 +138,7 @@ object VpnController : KoinComponent {
         braveVpnService?.signalStopService(true)
         braveVpnService = null
         onConnectionStateChanged(connectionState)
+        persistentState.setVpnEnabled(false)
     }
 
     fun state(): VpnState {


### PR DESCRIPTION
* `ACTIVE_TILE` is disabled to prevent tile not resetting to off after app being killed by system/crashing;
* `TOGGLEABLE_TILE` is enabled to improve accessibility;
* Fix tile not updating after clicking.

Tested on emulator. Fixes #57 #101.