### PR TITLE
Use START_STICKY

### DIFF
--- a/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
@@ -1222,7 +1222,7 @@ class BraveVPNService :
                 observeChanges()
             }
         }
-        return Service.START_REDELIVER_INTENT
+        return Service.START_STICKY
     }
 
     private fun startOrbotAsyncIfNeeded() {


### PR DESCRIPTION
According to [Android official documentations](https://developer.android.com/reference/android/app/Service#service-lifecycle), START_STICKY is used for services that are explicitly started and stopped as needed, while START_NOT_STICKY or START_REDELIVER_INTENT are used for services that should only remain running while processing any commands sent to them.