### PR TITLE
Set VPN notification persistent

### DIFF
--- a/app/src/full/java/com/celzero/bravedns/ui/MiscSettingsActivity.kt
+++ b/app/src/full/java/com/celzero/bravedns/ui/MiscSettingsActivity.kt
@@ -213,7 +213,9 @@ class MiscSettingsActivity : AppCompatActivity(R.layout.activity_misc_settings) 
                 !b.settingsActivityAutoStartSwitch.isChecked
         }
 
-        b.settingsActivityAutoStartSwitch.setOnCheckedChangeListener { _: CompoundButton, b: Boolean
+        b.settingsActivityAutoStartSwitch.setOnCheckedChangeListener {
+            _: CompoundButton,
+            b: Boolean
             ->
             persistentState.prefAutoStartBootUp = b
         }
@@ -246,6 +248,17 @@ class MiscSettingsActivity : AppCompatActivity(R.layout.activity_misc_settings) 
         b.settingsActivityNotificationRl.setOnClickListener {
             enableAfterDelay(TimeUnit.SECONDS.toMillis(1L), b.settingsActivityNotificationRl)
             showNotificationActionDialog()
+        }
+
+        b.settingsActivityAppNotificationPersistentRl.setOnClickListener {
+            b.settingsActivityAppNotificationPersistentSwitch.isChecked =
+                !b.settingsActivityAppNotificationPersistentSwitch.isChecked
+        }
+
+        b.settingsActivityAppNotificationPersistentSwitch.setOnCheckedChangeListener {
+            _: CompoundButton,
+            b: Boolean ->
+            persistentState.persistentNotification = b
         }
 
         b.settingsActivityPcapRl.setOnClickListener {

--- a/app/src/full/res/layout/activity_misc_settings.xml
+++ b/app/src/full/res/layout/activity_misc_settings.xml
@@ -722,6 +722,60 @@
                         android:padding="10dp" />
                 </RelativeLayout>
 
+                <RelativeLayout
+                    android:id="@+id/settings_activity_app_notification_persistent_rl"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:paddingTop="15dp"
+                    android:paddingBottom="15dp">
+
+                    <androidx.appcompat.widget.AppCompatImageView
+                        android:id="@+id/settings_activity_app_notification_persistent_icon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_centerVertical="true"
+                        android:layout_marginStart="5dp"
+                        android:layout_marginTop="5dp"
+                        android:layout_marginEnd="5dp"
+                        android:layout_marginBottom="5dp"
+                        android:padding="10dp"
+                        android:src="@drawable/ic_notification" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_centerVertical="true"
+                        android:layout_toStartOf="@id/settings_activity_app_notification_persistent_switch"
+                        android:layout_toEndOf="@id/settings_activity_app_notification_persistent_icon"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/gen_settings_app_notification_persistent_txt"
+                            style="@style/TextAppearance.AppCompat.Subhead"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/settings_app_notification_persistent_heading"
+                            android:textSize="@dimen/large_font_text_view" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingTop="5dp"
+                            android:text="@string/settings_app_notification_persistent_desc"
+                            android:textSize="@dimen/default_font_text_view" />
+                    </LinearLayout>
+
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/settings_activity_app_notification_persistent_switch"
+                        style="@style/CustomWidget.MaterialComponents.CompoundButton.Switch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentEnd="true"
+                        android:layout_centerVertical="true"
+                        android:padding="10dp" />
+                </RelativeLayout>
+
             </LinearLayout>
         </com.google.android.material.card.MaterialCardView>
     </LinearLayout>

--- a/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
@@ -1094,6 +1094,7 @@ class BraveVPNService :
 
         builder.setSmallIcon(R.drawable.ic_notification_icon).setContentIntent(pendingIntent)
         builder.color = ContextCompat.getColor(this, getAccentColor(persistentState.theme))
+        builder.setOngoing(true)
 
         // New action button options in the notification
         // 1. Pause / Resume, Stop action button.

--- a/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
@@ -1094,7 +1094,11 @@ class BraveVPNService :
 
         builder.setSmallIcon(R.drawable.ic_notification_icon).setContentIntent(pendingIntent)
         builder.color = ContextCompat.getColor(this, getAccentColor(persistentState.theme))
-        builder.setOngoing(true)
+
+        if (persistentState.persistentNotification)
+        {
+            builder.setOngoing(true)
+        }
 
         // New action button options in the notification
         // 1. Pause / Resume, Stop action button.

--- a/app/src/main/java/com/celzero/bravedns/service/PersistentState.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/PersistentState.kt
@@ -239,6 +239,10 @@ class PersistentState(context: Context) : SimpleKrate(context), KoinComponent {
     var shouldRequestNotificationPermission by
         booleanPref("notification_permission_request").withDefault<Boolean>(true)
 
+    // make notification persistent
+    var persistentNotification by
+            booleanPref("persistent_notification").withDefault<Boolean>(false)
+
     // biometric authentication
     var biometricAuth by booleanPref("biometric_authentication").withDefault<Boolean>(false)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -473,6 +473,9 @@
     <string name="settings_app_notification_a13_heading" translatable="true">App Notification</string>
     <string name="settings_app_notification_a13_desc" translatable="true">Enable notification permission for the app</string>
 
+    <string name="settings_app_notification_persistent_heading" translatable="true">Persistent Notification</string>
+    <string name="settings_app_notification_persistent_desc" translatable="true">Make the notification persistent</string>
+
     <string name="settings_theme_heading" translatable="true">Appearance</string>
     <string name="settings_theme_desc" translatable="true">Dark/light theme</string>
 


### PR DESCRIPTION
As per #1136 , the notification for the active VPN is dismisable. Therefore, it is easy to swipe it away and kill the app. This one-line change makes the notification "ongoing".