### PR TITLE
tunnel: stop vpn adapter when another app takes over the vpn

### DIFF
--- a/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
@@ -1942,6 +1942,11 @@ class BraveVPNService :
         }
     }
 
+    override fun onRevoke() {
+        stopVpnAdapter()
+        super.onRevoke()
+    }
+
     private suspend fun restartVpnWithNewAppConfig(
         underlyingNws: ConnectionMonitor.UnderlyingNetworks? = underlyingNetworks,
         overlayNws: OverlayNetworks = overlayNetworks,


### PR DESCRIPTION
fixes: #1545

This small change fixes the issue mentioned in the referenced issue. When another app takes over the VPN, `onRevoke()` method of the `VpnService()` is called which wasn't overriden to call `stopVpnAdapter()` which closes the tunnel.

Overriding `onRevoke()` to call `stopVpnAdapter()` ensures the tunnel is closed gracefully when another app starts the VPN.