### PR TITLE
Set text color of app name based on its type - system, user or no-internet.

### DIFF
--- a/app/src/full/java/com/celzero/bravedns/adapter/FirewallAppListAdapter.kt
+++ b/app/src/full/java/com/celzero/bravedns/adapter/FirewallAppListAdapter.kt
@@ -106,15 +106,14 @@ class FirewallAppListAdapter(
                 val connStatus = FirewallManager.connectionStatus(appInfo.uid)
                 uiCtx {
                     b.firewallAppLabelTv.text = appInfo.appName
-                    if (appInfo.hasInternetPermission(packageManager)) {
-                        if (appInfo.isSystemApp) {
-                            b.firewallAppLabelTv.setTextColor(systemAppColor)
-                        } else {
-                            b.firewallAppLabelTv.setTextColor(userAppColor)
-                            b.firewallAppLabelTv.alpha = 1f
-                        }
+                    if (appInfo.isSystemApp) {
+                        b.firewallAppLabelTv.setTextColor(systemAppColor)
                     } else {
                         b.firewallAppLabelTv.setTextColor(userAppColor)
+                    }
+                    if (appInfo.hasInternetPermission(packageManager)) {
+                        b.firewallAppLabelTv.alpha = 1f
+                    } else {
                         b.firewallAppLabelTv.alpha = 0.6f
                     }
                     b.firewallAppToggleOther.text = getFirewallText(appStatus, connStatus)

--- a/app/src/full/java/com/celzero/bravedns/adapter/FirewallAppListAdapter.kt
+++ b/app/src/full/java/com/celzero/bravedns/adapter/FirewallAppListAdapter.kt
@@ -42,6 +42,7 @@ import com.celzero.bravedns.service.FirewallManager
 import com.celzero.bravedns.service.FirewallManager.updateFirewallStatus
 import com.celzero.bravedns.ui.activity.AppInfoActivity
 import com.celzero.bravedns.ui.activity.AppInfoActivity.Companion.UID_INTENT_NAME
+import com.celzero.bravedns.util.UIUtils
 import com.celzero.bravedns.util.Utilities
 import com.celzero.bravedns.util.Utilities.getIcon
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
@@ -56,8 +57,8 @@ class FirewallAppListAdapter(
 ) : PagingDataAdapter<AppInfo, FirewallAppListAdapter.AppListViewHolder>(DIFF_CALLBACK) {
 
     private val packageManager: PackageManager = context.packageManager
-    private val systemAppColor: Int by lazy { getColorFromAttr(R.attr.textColorAccentBad) }
-    private val userAppColor: Int by lazy { getColorFromAttr(R.attr.primaryTextColor) }
+    private val systemAppColor: Int by lazy { UIUtils.fetchColor(context, R.attr.textColorAccentBad) }
+    private val userAppColor: Int by lazy { UIUtils.fetchColor(context, R.attr.primaryTextColor) }
 
     companion object {
         private val DIFF_CALLBACK =
@@ -105,7 +106,7 @@ class FirewallAppListAdapter(
                 val connStatus = FirewallManager.connectionStatus(appInfo.uid)
                 uiCtx {
                     b.firewallAppLabelTv.text = appInfo.appName
-                    if (appInfo.hasInternetPermission(appInfo.packageName, packageManager)) {
+                    if (appInfo.hasInternetPermission(packageManager)) {
                         if (appInfo.isSystemApp) {
                             b.firewallAppLabelTv.setTextColor(systemAppColor)
                         } else {
@@ -114,7 +115,7 @@ class FirewallAppListAdapter(
                         }
                     } else {
                         b.firewallAppLabelTv.setTextColor(userAppColor)
-                        b.firewallAppLabelTv.alpha = 0.7f
+                        b.firewallAppLabelTv.alpha = 0.6f
                     }
                     b.firewallAppToggleOther.text = getFirewallText(appStatus, connStatus)
                     displayIcon(
@@ -517,11 +518,5 @@ class FirewallAppListAdapter(
 
     private suspend fun ioCtx(f: suspend () -> Unit) {
         withContext(Dispatchers.IO) { f() }
-    }
-
-    private fun getColorFromAttr(attr: Int): Int {
-        val typedValue = TypedValue()
-        context.theme.resolveAttribute(attr, typedValue, true)
-        return ContextCompat.getColor(context, typedValue.resourceId)
     }
 }

--- a/app/src/main/java/com/celzero/bravedns/database/AppInfo.kt
+++ b/app/src/main/java/com/celzero/bravedns/database/AppInfo.kt
@@ -15,7 +15,9 @@
  */
 package com.celzero.bravedns.database
 
+import android.Manifest
 import android.content.ContentValues
+import android.content.pm.PackageManager
 import androidx.room.Entity
 import com.celzero.bravedns.service.FirewallManager
 
@@ -94,5 +96,10 @@ class AppInfo {
         this.isProxyExcluded = isProxyExcluded
         this.screenOffAllowed = screenOffAllowed
         this.backgroundAllowed = backgroundAllowed
+    }
+
+    fun hasInternetPermission(packageName: String, packageManager: PackageManager): Boolean {
+        // INTERNET permission if defined, can not be denied so this is safe to use
+        return packageManager.checkPermission(Manifest.permission.INTERNET, packageName) == PackageManager.PERMISSION_GRANTED
     }
 }

--- a/app/src/main/java/com/celzero/bravedns/database/AppInfo.kt
+++ b/app/src/main/java/com/celzero/bravedns/database/AppInfo.kt
@@ -98,7 +98,7 @@ class AppInfo {
         this.backgroundAllowed = backgroundAllowed
     }
 
-    fun hasInternetPermission(packageName: String, packageManager: PackageManager): Boolean {
+    fun hasInternetPermission(packageManager: PackageManager): Boolean {
         // INTERNET permission if defined, can not be denied so this is safe to use
         return packageManager.checkPermission(Manifest.permission.INTERNET, packageName) == PackageManager.PERMISSION_GRANTED
     }


### PR DESCRIPTION
Set text color of app name based on its type - system, user or no-internet.

With this change, System apps will be colored as Red, user apps as Primary color and apps without internet access as disabled (reduced alpha of red/primary color based on app's type).

I feel this is useful to quickly identify an app in the list.