### PR TITLE
Added VPN controller for automation integrations

### DIFF
--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -140,6 +140,15 @@
             </intent-filter>
         </receiver>
         <receiver
+            android:name=".receiver.VPNControlReceiver"
+            android:exported="true"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="com.celzero.bravedns.intent.action.VPN_START" />
+                <action android:name="com.celzero.bravedns.intent.action.VPN_STOP" />
+            </intent-filter>
+        </receiver>
+        <receiver
             android:name=".receiver.NotificationActionReceiver"
             android:exported="false"
             android:label="@string/app_name" />

--- a/app/src/full/java/com/celzero/bravedns/receiver/VPNControlReceiver.kt
+++ b/app/src/full/java/com/celzero/bravedns/receiver/VPNControlReceiver.kt
@@ -35,6 +35,8 @@ class VPNControlReceiver : BroadcastReceiver(), KoinComponent {
                     Logger.i(LOG_TAG_VPN, "Attempting to prepare VPN before starting")
                     VpnService.prepare(context)
                 } catch (e: NullPointerException) {
+                    // This shouldn't happen normally as Broadcast Intent sender apps like Tasker won't come up as early as Always-on VPNs
+                    // Context can be null in case of auto-restart VPNs: https://stackoverflow.com/questions/73147633/getting-null-in-context-while-auto-restart-with-broadcast-receiver-in-android-ap
                     Logger.w(LOG_TAG_VPN, "Device does not support system-wide VPN mode")
                     return
                 }

--- a/app/src/full/java/com/celzero/bravedns/receiver/VPNControlReceiver.kt
+++ b/app/src/full/java/com/celzero/bravedns/receiver/VPNControlReceiver.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 RethinkDNS and its authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.celzero.bravedns.receiver
+
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.celzero.bravedns.service.VpnController
+import org.koin.core.component.KoinComponent
+
+class VPNControlReceiver : BroadcastReceiver(), KoinComponent {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action == ACTION_START) {
+            VpnController.start(context)
+        }
+        if (intent.action == ACTION_STOP) {
+            VpnController.stop(context)
+        }
+    }
+
+    companion object {
+        private const val ACTION_START = "com.celzero.bravedns.intent.action.VPN_START"
+        private const val ACTION_STOP = "com.celzero.bravedns.intent.action.VPN_STOP"
+    }
+}


### PR DESCRIPTION
Implemented a solution to handle automation based on Intents and broadcasts.
Based on suggestion: https://github.com/celzero/rethink-app/issues/1294#issuecomment-2359468242

To configure an automation, in Tasker: (Ref: [Reddit thread](https://www.reddit.com/r/Tailscale/comments/141rkyy/tutorial_turn_taiscale_onoff_automatically_using/))
- add a new task, let's call it "RethinkDNS connect"
- in the task, add a "Send intent" action, you can use the search bar to bring it up
- fill in the following fields and leave the rest as default:
  - Package: `com.celzero.bravedns`
  - Class: `com.celzero.bravedns.VPNControlReceiver`
  - Action: `com.celzero.bravedns.intent.action.VPN_START` -> For start up
  - Action `com.celzero.bravedns.intent.action.VPN_STOP` -> For shutdown

To configure an automation, in Automate: (Ref: [Reddit comment](https://www.reddit.com/r/AutomateUser/comments/18311fn/comment/kaonpuv/))
- using the [Broadcast send](https://llamalab.com/automate/doc/block/broadcast_send.html) block

  - Package: `com.celzero.bravedns`
  - Receiver class: `com.celzero.bravedns.VPNControlReceiver`
  - Action: `com.celzero.bravedns.intent.action.VPN_START` -> For start up
  - Action `com.celzero.bravedns.intent.action.VPN_STOP` -> For shutdown


Should resolve issues related to supporting automation: https://github.com/celzero/rethink-app/issues/63, https://github.com/celzero/rethink-app/issues/1294

