### PR TITLE
android-ci: modify android workflow to enforce SDK versions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -42,6 +42,12 @@ jobs:
     - name: 🚂 Assemble
       if: success()
       run: |
-        ./gradlew lint
-        ./gradlew assembleWebsiteFullDebug --info --warning-mode all
-
+        # Force compileSdk 36 for all variants
+        ./gradlew \
+          assembleWebsiteFullDebug \
+          assembleFdroidFullDebug \
+          -Pandroid.compileSdk=36 \
+          -Pandroid.buildToolsVersion=36.0.0 \
+          -Pandroid.targetSdk=36 \
+          --info \
+          --warning-mode all


### PR DESCRIPTION
Updated Android build process to force compileSdk and build tools version.