### PR TITLE
CustomDomainFragment: use viewLifecycleOwner so observers don't outlive their View

### DIFF
--- a/app/src/full/java/com/celzero/bravedns/ui/fragment/CustomDomainFragment.kt
+++ b/app/src/full/java/com/celzero/bravedns/ui/fragment/CustomDomainFragment.kt
@@ -128,8 +128,8 @@ class CustomDomainFragment :
         adapter = CustomDomainAdapter(requireContext(), this, rule, eventLogger)
         b.cdaRecycler.adapter = adapter
         viewModel.setUid(uid)
-        viewModel.customDomains.observe(this as LifecycleOwner) {
-            adapter.submitData(this.lifecycle, it)
+        viewModel.customDomains.observe(viewLifecycleOwner) {
+            adapter.submitData(viewLifecycleOwner.lifecycle, it)
         }
         io {
             val appName = FirewallManager.getAppNameByUid(uid)
@@ -156,8 +156,8 @@ class CustomDomainFragment :
         observeAllRules()
         adapter = CustomDomainAdapter(requireContext(), this, rule, eventLogger)
         b.cdaRecycler.adapter = adapter
-        viewModel.allDomainRules.observe(this as LifecycleOwner) {
-            adapter.submitData(this.lifecycle, it)
+        viewModel.allDomainRules.observe(viewLifecycleOwner) {
+            adapter.submitData(viewLifecycleOwner.lifecycle, it)
         }
     }
 


### PR DESCRIPTION
## Problem

In `CustomDomainFragment.setupAppSpecificRules()` and `setupAllRules()`, two LiveData subscriptions use `this as LifecycleOwner` — the Fragment's own lifecycle rather than its View's:

```kotlin
viewModel.customDomains.observe(this as LifecycleOwner) {
    adapter.submitData(this.lifecycle, it)
}
```

A Fragment instance outlives its View when the Fragment is on the back stack (the View is destroyed in `onDestroyView()` but the Fragment instance is retained). On backstack pop + push, `customDomains` / `allDomainRules` can re-emit while the observer is still registered, and `adapter.submitData()` is then called against an adapter whose RecyclerView has been torn down. Depending on timing this can surface as silent stale-data, an NPE from the adapter's internal data set, or `IllegalStateException: Cannot call this method while RecyclerView is computing a layout`.

This is the canonical Fragment-vs-Fragment-View lifecycle pitfall.

## Fix

Switch both observers to `viewLifecycleOwner`, and use `viewLifecycleOwner.lifecycle` for `submitData` so the Paging library disposes the data flow with the View:

```kotlin
viewModel.customDomains.observe(viewLifecycleOwner) {
    adapter.submitData(viewLifecycleOwner.lifecycle, it)
}
```

## Why this is safe

Both call sites are reached from `onViewCreated()` (line 81) via `setupAppSpecificRules()` / `setupAllRules()` — so the View is guaranteed to exist and `viewLifecycleOwner` is valid. (`viewLifecycleOwner` only throws IllegalStateException before `onCreateView()` completes or after `onDestroyView()` runs.)

Configuration change is handled correctly: the new View gets a fresh `viewLifecycleOwner` and observes against it; the old observer is auto-disposed on the previous View's destruction.

## Edge cases checked

- `viewLifecycleOwner` availability at the call site → guaranteed by being inside the `onViewCreated()` chain ✓
- Other Fragments with the same pattern → \`grep -rn 'observe(this' app/src/**/*Fragment.kt\` shows these are the **only two** occurrences across all Fragments. No collateral fix needed.
- The `adapter.submitData(lifecycle, ...)` change → matches the Paging 3 example which uses `viewLifecycleOwner.lifecycle` from a Fragment.

## Tested

Built debug APK with the change, installed on a Pixel-class device:

- Opened Custom Domains from Apps → individual app → Custom rules
- Added/removed rules → list updated reactively (observer fires correctly via viewLifecycleOwner) ✓
- Pressed back, re-entered the same screen → fresh observer attached, no orphaned subscription ✓
- Configuration change (rotate) → list re-bound cleanly ✓
- No IllegalStateException / NPE in logcat after stress-toggling rules