### PR TITLE
VpnController: use SupervisorJob for externalScope so child failures don't cascade

### DIFF
--- a/app/src/main/java/com/celzero/bravedns/service/VpnController.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/VpnController.kt
@@ -40,6 +40,7 @@ import com.celzero.firestack.backend.RpnEntitlement
 import com.celzero.firestack.intra.Controller
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
@@ -74,7 +75,7 @@ object VpnController : KoinComponent {
     // TODO: make clients listen on create, start, stop, destroy from vpn-service
     fun onVpnCreated(b: BraveVPNService) {
         braveVpnService = b
-        externalScope = CoroutineScope(Dispatchers.IO)
+        externalScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         states = Channel(Channel.CONFLATED) // drop unconsumed states
 
         // store app start time, used in HomeScreenBottomSheet


### PR DESCRIPTION
## Problem

`VpnController.externalScope` in `onVpnCreated()` is constructed as:

```kotlin
externalScope = CoroutineScope(Dispatchers.IO)
```

Without an explicit `Job` argument, `CoroutineScope` constructs a plain `Job()` for the scope. Under structured concurrency rules, a plain `Job` propagates child failures upward: when any one child coroutine fails with an exception, the parent `Job` cancels, which cascades cancellation to **every sibling** in the same scope.

`externalScope` currently has two child paths:

1. The state-consumer in `onVpnCreated()` itself:
   ```kotlin
   externalScope!!.launch {
       states!!.consumeEach { state ->
           ...
       }
   }
   ```
2. The state-emitter in `onConnectionStateChanged()`:
   ```kotlin
   externalScope?.launch { states?.send(state) }
   ```

If any future addition to `externalScope` throws, or if the consumer's `when (state)` block hits an unexpected case that propagates upward, the entire state-update pipeline collapses silently. The UI then stops reflecting connection-state transitions until the next VPN restart.

## Fix

```kotlin
externalScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
```

`SupervisorJob` isolates child failures: a thrown exception in one child does not cancel siblings. Each independent coroutine is responsible for its own error handling.

## Why this is safe

- **Cancellation semantics unchanged**: the existing `externalScope?.cancel("VPNController - onVpnDestroyed")` in `onVpnDestroyed()` still propagates cancellation to all children. SupervisorJob differs from Job only in the *upward* cancellation direction (child → parent), not the *downward* one.
- **No behavior change in the happy path**: state pipeline operates identically when no child throws.
- **Recommended pattern** for object-lifetime scopes per the [Kotlin coroutines guide](https://kotlinlang.org/docs/exceptions.html#supervision-job): "A good example of such a requirement is a UI component with the job defined in its scope. If any of the UI's child tasks have failed, it is not always necessary to cancel (effectively kill) the entire UI component, but if UI component is destroyed (and its job is cancelled), then it is necessary to cancel all child jobs as their results are no longer needed."

The `VpnController` is exactly this UI-component-with-job-in-its-scope pattern.

## Tested

- Built debug APK with the change. App launches, VPN starts and stops normally.
- Verified the connection-state transitions (NEW → CONNECTING → WORKING → IDLE → NEW) all propagate correctly through the consumer loop, identical to pre-change behavior.
- No new lint warnings.
- The `cancel("VPNController - onVpnDestroyed")` path still tears down on VPN-destroy without errors.

## Diff

One-line change + import:

```
+import kotlinx.coroutines.SupervisorJob
-        externalScope = CoroutineScope(Dispatchers.IO)
+        externalScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
```