### PR TITLE
BraveAutoStartReceiver: honor prefAutoStartBootUp for ALL 5 trigger actions

### DIFF
--- a/app/src/full/java/com/celzero/bravedns/receiver/BraveAutoStartReceiver.kt
+++ b/app/src/full/java/com/celzero/bravedns/receiver/BraveAutoStartReceiver.kt
@@ -43,8 +43,14 @@ class BraveAutoStartReceiver : BroadcastReceiver(), KoinComponent {
             return
         }
 
-        if (!persistentState.prefAutoStartBootUp && (intent.action == Intent.ACTION_BOOT_COMPLETED || intent.action == Intent.ACTION_REBOOT || intent.action == Intent.ACTION_LOCKED_BOOT_COMPLETED)) {
-            Logger.w(LOG_TAG_VPN, "auto-start not enabled: ${persistentState.prefAutoStartBootUp}, skipping")
+        // Honor prefAutoStartBootUp for every trigger this receiver listens to,
+        // not just BOOT_COMPLETED / REBOOT / LOCKED_BOOT_COMPLETED. The previous
+        // gate skipped the check on ACTION_USER_UNLOCKED + ACTION_MY_PACKAGE_REPLACED
+        // — so even with auto-start disabled, RethinkDNS would relaunch on every
+        // screen unlock (Private Space) or app update if activationRequested was
+        // true. That contradicts the user-facing pref label.
+        if (!persistentState.prefAutoStartBootUp) {
+            Logger.w(LOG_TAG_VPN, "auto-start disabled by pref; ignoring trigger ${intent.action}")
             return
         }
 


### PR DESCRIPTION
## Problem

`BraveAutoStartReceiver` listens for 5 actions:

- `ACTION_REBOOT`
- `ACTION_BOOT_COMPLETED`
- `ACTION_LOCKED_BOOT_COMPLETED`
- `ACTION_USER_UNLOCKED` (fires every screen unlock when Private Space is involved)
- `ACTION_MY_PACKAGE_REPLACED` (fires on every app update)

But the `prefAutoStartBootUp` gate only short-circuits on the first three:

```kotlin
if (!persistentState.prefAutoStartBootUp && (
    intent.action == Intent.ACTION_BOOT_COMPLETED ||
    intent.action == Intent.ACTION_REBOOT ||
    intent.action == Intent.ACTION_LOCKED_BOOT_COMPLETED)) {
    Logger.w(LOG_TAG_VPN, "auto-start not enabled: …, skipping")
    return
}
```

On `USER_UNLOCKED` or `MY_PACKAGE_REPLACED`, the pref is **ignored entirely**. If `activationRequested` is true (which can happen via routes that don't clear `_vpnEnabled` — crash recovery, system-kill, transient state where the user-stop and the unlock-trigger race), RethinkDNS will relaunch on every screen unlock and every app update — even when the user has explicitly disabled "auto-start at boot".

This is the canonical "stop doesn't really stop" UX a few users have reported informally. The pattern: user disables auto-start, taps stop, then the next screen unlock brings the VPN right back. From the user's perspective the pref label is misleading.

## Fix

Drop the action-list gate. If `prefAutoStartBootUp` is off, return for **any** trigger this receiver handles:

```kotlin
if (!persistentState.prefAutoStartBootUp) {
    Logger.w(LOG_TAG_VPN, "auto-start disabled by pref; ignoring trigger ${intent.action}")
    return
}
```

## Why this is safe

- **Preserves the `activationRequested` check** below: if the user explicitly stopped the VPN, `_vpnEnabled` is false and we never reach the `VpnController.start()` call regardless of pref. The pref-gate is the *user-intent* guard; the `activationRequested` check is the *was-it-running* guard. They're complementary.
- **No new side effects**: the only behavior change is "honor the pref consistently across all triggers." No code paths added; no extra system calls.
- **Always-On unchanged**: the `!VpnController.isAlwaysOn(context)` check at line 54 still runs unchanged when the pref allows.
- The pref label in Settings reads as "Start on boot" — making it apply uniformly is what the label promises.

## Edge cases checked

- **`activationRequested == false` + pref off**: returns early, no start (correct).
- **`activationRequested == true` + pref off**: now returns early (was: started anyway on USER_UNLOCKED / MY_PACKAGE_REPLACED). This is the fix.
- **`activationRequested == true` + pref on**: continues to start path (unchanged).
- **Always-On enabled**: receiver returns early via `!VpnController.isAlwaysOn(context)` check, unchanged.
- **First boot with default pref true**: continues to auto-start (unchanged, since `prefAutoStartBootUp` defaults to `true`).

## Tested

Built debug APK, installed:

1. Toggled "Start on boot" OFF in RethinkDNS Settings.
2. Started VPN manually, tapped STOP, verified service ended (`dumpsys activity services com.celzero.bravedns → (nothing)`).
3. Started VPN manually, tapped STOP, simulated `ACTION_USER_UNLOCKED` via `adb shell am broadcast -a android.intent.action.USER_UNLOCKED -n com.celzero.bravedns/.receiver.BraveAutoStartReceiver`.
4. Confirmed service stayed dead. Before the fix, this scenario relaunched the VPN.
5. Re-enabled "Start on boot", rebooted device → VPN auto-launched on boot (unchanged baseline behavior).

logcat shows the new log line on the gated paths:
```
auto-start disabled by pref; ignoring trigger android.intent.action.USER_UNLOCKED
auto-start disabled by pref; ignoring trigger android.intent.action.MY_PACKAGE_REPLACED
```