### PR TITLE
BraveVPNService.onDestroy: STOP_FOREGROUND_REMOVE so notification clears on stop

### DIFF
--- a/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
@@ -3446,9 +3446,13 @@ class BraveVPNService : VpnService(), ConnectionMonitor.NetworkListener, Bridge,
 
         Logger.w(LOG_TAG_VPN, "Destroying VPN service")
 
-        // stop foreground service will take care of stopping the service for both
-        // version >= 24 and < 24
-        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_DETACH)
+        // Use STOP_FOREGROUND_REMOVE so the persistent VPN-active notification clears
+        // when the service ends. STOP_FOREGROUND_DETACH only strips the service's
+        // foreground status while leaving the notification visible — which causes
+        // a stale "RethinkDNS protected" notification to linger after the user has
+        // stopped the VPN, until the user manually swipes it away or the service is
+        // re-created. REMOVE is the right semantics for "we're done, clean up."
+        ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
     }
 
     private fun startPauseTimer() {


### PR DESCRIPTION
## Problem

`BraveVPNService.onDestroy()` currently calls:

\`\`\`kotlin
ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_DETACH)
\`\`\`

`STOP_FOREGROUND_DETACH` strips the service's foreground status while **leaving the persistent notification visible**. After the user taps Stop (or the service is destroyed via any other path), the "RethinkDNS protected" notification lingers until the user either manually swipes it away or the service is re-created. This is confusing UX: the user has just stopped the VPN, yet sees what looks like an "active" notification.

## Fix

Switch to `STOP_FOREGROUND_REMOVE`:

\`\`\`kotlin
ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
\`\`\`

`REMOVE` clears the notification along with the foreground flag — which is what `onDestroy()` actually wants: this is the final cleanup, not a "keep showing the user we're still around" stop.

## Why this is safe

- `ServiceCompat.stopForeground` is the AndroidX shim that handles the API-level differences. Both `STOP_FOREGROUND_REMOVE` and `STOP_FOREGROUND_DETACH` are supported on all API levels this app targets.
- This is `onDestroy()` — the service is going away anyway. Whether the foreground notification is detached-and-left-visible vs detached-and-removed is purely a UI-cleanup choice; service lifecycle is unchanged.
- No tunnel/network impact. The VPN tunnel is already being torn down via `stopVpnAdapter` and related cleanup earlier in `onDestroy`.

## Tested

- Built debug APK, installed.
- Started VPN, verified persistent notification appears with "VPN active" / similar.
- Tapped Stop from in-app.
- After this fix: notification clears immediately along with the service. Before the fix: notification stays visible until manually dismissed or until next service start.
- Repeated the cycle 5x — no leaked or duplicate notifications.