### PR TITLE
ConsoleLogActivity: disable item-prefetch to prevent #2591 IOOBE at the source

### DIFF
--- a/app/src/full/java/com/celzero/bravedns/ui/activity/ConsoleLogActivity.kt
+++ b/app/src/full/java/com/celzero/bravedns/ui/activity/ConsoleLogActivity.kt
@@ -174,6 +174,21 @@ class ConsoleLogActivity : BaseActivity(R.layout.activity_console_log), androidx
                     }
                 }
             }
+            // Disable RecyclerView's GapWorker-driven item prefetch on this list.
+            // The console log is updated at very high frequency by background logging
+            // coroutines (Paging 3 inserts), and prefetch races with the paging
+            // update path to produce the IndexOutOfBoundsException in ConsoleLogAdapter
+            // reported as #2591 ("v055u: IndexOutOfBoundsException ConsoleLogAdapter").
+            // The existing try/catch above SWALLOWS the exception when it does fire;
+            // this prevents the race that causes it. Trade-off: marginally slower
+            // scroll because the next item is bound on-demand instead of one-frame
+            // ahead. For a debug log view that's a non-issue.
+            //
+            // Note: ConnectionTrackerFragment / DnsLogFragment elsewhere in this app
+            // explicitly enable prefetch (lm.isItemPrefetchEnabled = true). The
+            // console log has a fundamentally higher write rate so the default needs
+            // to differ.
+            (layoutManager as? LinearLayoutManager)?.isItemPrefetchEnabled = false
 
             b.consoleLogList.layoutManager = layoutManager
             recyclerAdapter = ConsoleLogAdapter(this)


### PR DESCRIPTION
## Closes-or-helps

[#2591 — v055u: IndexOutOfBoundsException ConsoleLogAdapter](https://github.com/celzero/rethink-app/issues/2591)

## Problem

`ConsoleLogActivity.setAdapter()` already wraps the layout manager's `onLayoutChildren` in a try/catch that swallows the `IndexOutOfBoundsException`:

\`\`\`kotlin
layoutManager = object : LinearLayoutManager(this@ConsoleLogActivity) {
    override fun onLayoutChildren(recycler: …, state: …) {
        try { super.onLayoutChildren(recycler, state) }
        catch (e: IndexOutOfBoundsException) {
            Logger.w(LOG_TAG_UI, "err(console) layout children: \${e.message}")
        }
    }
}
\`\`\`

That catch is **defensive** but only fires *after* the race has already produced the exception (visible as repeated "err(console) layout children" log spam under heavy logging).

The race itself is RecyclerView's `GapWorker`-driven item-prefetch competing with the Paging 3 insert path. The console log gets thousands of writes per minute from background logging coroutines; prefetch tries to bind item N+1 while paging is mutating that index, producing IOOBE.

## Fix

Set `layoutManager.isItemPrefetchEnabled = false` after constructing the layout manager. This prevents the race that triggers the exception in the first place. The existing try/catch stays in place as belt-and-suspenders:

\`\`\`kotlin
(layoutManager as? LinearLayoutManager)?.isItemPrefetchEnabled = false
\`\`\`

Both layers together = no exception, no log spam, no incorrect view binding.

## Why this is safe / why this trade-off

- **Trade-off**: scroll-ahead binding is disabled, so the *next* item is bound on the frame it scrolls into view instead of one frame ahead. For a debug log console with very high update rate, this is the right call.
- **Pattern verification**: \`ConnectionTrackerFragment\` (line 159) and \`DnsLogFragment\` (line 172) elsewhere in this codebase **explicitly enable** prefetch (`lm.isItemPrefetchEnabled = true`). The console log has fundamentally higher write rate (it logs everything, including paging operations), so the opposite default is warranted here. This is a per-list policy decision, not a global one.
- The existing try/catch is preserved unchanged.

## Tested

- Built debug APK, opened Console Log with `Logger.uiLogLevel = VERBOSE` so log lines flow in faster than the screen can render.
- Before this fix: `logcat | grep 'err(console)'` showed steady "layout children" warnings; the screen occasionally flickered as IOOBE was swallowed mid-paint.
- After this fix: zero "err(console)" warnings in logcat over a 60-second high-load test; scroll behavior smooth.
- Filtering by log level (VERBOSE / INFO / WARN / ERROR) still works correctly.