### PR TITLE
Sort saved WireGuard configs alphabetically

### DIFF
--- a/app/src/main/java/com/celzero/bravedns/database/WgConfigFilesDAO.kt
+++ b/app/src/main/java/com/celzero/bravedns/database/WgConfigFilesDAO.kt
@@ -35,12 +35,12 @@ interface WgConfigFilesDAO {
     @Insert(onConflict = OnConflictStrategy.REPLACE) fun insert(wgConfigFiles: WgConfigFiles): Long
 
     @Query(
-        "select * from WgConfigFiles order by isActive desc"
+        "select * from WgConfigFiles order by isActive desc, name collate nocase asc"
     )
     fun getWgConfigsLiveData(): PagingSource<Int, WgConfigFiles>
 
     @Query(
-        "select * from WgConfigFiles order by isActive desc"
+        "select * from WgConfigFiles order by isActive desc, name collate nocase asc"
     )
     fun getWgConfigs(): List<WgConfigFiles>
 


### PR DESCRIPTION
## Summary
Saved WireGuard configs now list in a deterministic order (active first, then case-insensitive alphabetical by name), via the two list queries in WgConfigFilesDAO.kt.

## Why this matters
The saved WireGuard profile list currently orders only by `isActive desc`, so inactive configs fall back to SQLite's unspecified (rowid/insertion) order and the list looks arbitrary to users. Adding `name collate nocase asc` as a secondary sort gives a stable, intuitive alphabetical order while keeping the active tunnel pinned at the top. See https://github.com/celzero/rethink-app/issues/2647

This intentionally implements just the deterministic-default-order slice the reporter leads with, not the larger bulk-add / grouping / search-bar asks, which are a separate UI scope and a maintainer design decision.

## Testing
- Verified `name` and `isActive` are real, non-null columns on the `WgConfigFiles` entity (`name: String = ""`, `isActive: Boolean = false`), so the secondary sort needs no null handling and matches Room's compile-time query validation against the schema.
- Reviewed the SQL: `order by isActive desc, name collate nocase asc` is native SQLite; `collate nocase` yields the case-insensitive alphabetical ordering users expect, with no Kotlin-side comparator or index change. No schema/version change, so no DB migration is involved.
- Full Gradle build was not run here: no Android SDK is available in this headless environment. The change is a string-literal edit inside two existing `@Query` annotations against unchanged columns, so it carries no new compile surface beyond the SQL itself.

Fixes #2647
