### PR TITLE
fix: isActiveIfaceCellular returns metered flag instead of cellular flag

### DIFF
--- a/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
@@ -1286,7 +1286,7 @@ class BraveVPNService : VpnService(), ConnectionMonitor.NetworkListener, Bridge,
             val isCellular = cap.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
             curnet.isActiveNetworkCellular = isCellular
         }
-        return curnet.isActiveNetworkMetered
+        return curnet.isActiveNetworkCellular
     }
 
     private fun isAppBlocked(connectionStatus: FirewallManager.ConnectionStatus): Boolean {


### PR DESCRIPTION
## Summary
`isActiveIfaceCellular()` computes and caches the active interface's cellular-transport flag (`isActiveNetworkCellular`) but then returns `isActiveNetworkMetered` instead. On metered Wi-Fi with no cellular transport this makes the helper report the active interface as cellular when it is not, which can steer bind/route decisions toward a disabled cellular path.

## Why this matters
This is the source of the `empty destination ip, active cellular? true` log line in #2820: on airplane mode + metered Wi-Fi, cellular is off, yet the helper reports `active cellular? true` and connectivity intermittently breaks while traffic is attempted over the dead cellular interface. The sibling `isActiveIfaceMetered()` already returns `isActiveNetworkMetered` correctly, which confirms this is a copy-paste defect in the cellular variant rather than intended behavior. The `UnderlyingNetworks` data class already carries both flags, so no new state is needed.

## Testing
- Active network is unmetered Wi-Fi: returns false (now because cellular is false, not incidentally because metered is false).
- Active network is metered Wi-Fi with no cellular transport: returns false (previously returned true).
- Active network is cellular: returns true.
- No underlying networks set yet: returns false (early return preserved).
- `isActiveIfaceMetered()` is unaffected and still returns the metered flag.

Fixes #2820
