### PR TITLE
fix: rmv about screen unused whatsnew ui

### DIFF
--- a/app/src/full/java/com/celzero/bravedns/ui/fragment/AboutFragment.kt
+++ b/app/src/full/java/com/celzero/bravedns/ui/fragment/AboutFragment.kt
@@ -265,7 +265,6 @@ class AboutFragment : Fragment(R.layout.fragment_about), View.OnClickListener, K
         b.fossImg.setOnClickListener(this)
         b.flossFundsImg.setOnClickListener(this)
         b.aboutAppUpdate.setOnClickListener(this)
-        b.aboutWhatsNew.setOnClickListener(this)
         b.aboutAppInfo.setOnClickListener(this)
         b.aboutAppNotification.setOnClickListener(this)
         b.aboutVpnProfile.setOnClickListener(this)
@@ -327,10 +326,6 @@ class AboutFragment : Fragment(R.layout.fragment_about), View.OnClickListener, K
     private fun updateVersionInfo() {
         try {
             val version = getVersionName()
-            // take first 7 characters of the version name, as the version has build number
-            // appended to it, which is not required for the user to see.
-            val slicedVersion = version.slice(0..VERSION_SLICE_END_INDEX)
-            b.aboutWhatsNew.text = getString(R.string.about_whats_new, slicedVersion)
 
             // complete version name along with the source of installation
             val v = getString(R.string.about_version_install_source, version, getDownloadSource())
@@ -512,9 +507,6 @@ class AboutFragment : Fragment(R.layout.fragment_about), View.OnClickListener, K
                 (requireContext() as HomeScreenActivity).checkForUpdate(
                     AppUpdater.UserPresent.INTERACTIVE
                 )
-            }
-            b.aboutWhatsNew -> {
-                showNewFeaturesDialog()
             }
             b.aboutAppInfo -> {
                 openAppInfo(requireContext())
@@ -1705,6 +1697,7 @@ class AboutFragment : Fragment(R.layout.fragment_about), View.OnClickListener, K
         }
     }
 
+    // unused, remove after removing the string
     private fun showNewFeaturesDialog() {
         val binding =
             DialogWhatsnewBinding.inflate(LayoutInflater.from(requireContext()), null, false)

--- a/app/src/main/res/layout/fragment_about.xml
+++ b/app/src/main/res/layout/fragment_about.xml
@@ -351,23 +351,6 @@
                 android:textColor="?attr/colorPrimary" />
 
             <androidx.appcompat.widget.AppCompatTextView
-                android:id="@+id/about_whats_new"
-                style="@style/TextAppearance.AppCompat.Subhead"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="10dp"
-                android:layout_marginEnd="10dp"
-                android:background="?android:attr/selectableItemBackground"
-                android:drawableStart="@drawable/ic_whats_new"
-                android:drawablePadding="20dp"
-                android:visibility="gone"
-                android:gravity="start|center_vertical"
-                android:lineSpacingExtra="5dp"
-                android:padding="5dp"
-                android:text="@string/about_whats_new"
-                android:textSize="@dimen/large_font_text_view" />
-
-            <androidx.appcompat.widget.AppCompatTextView
                 android:id="@+id/about_app_update"
                 style="@style/TextAppearance.AppCompat.Subhead"
                 android:layout_width="match_parent"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed the “What’s New” entry from the About screen.
  * Removed the associated version label and interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->