### PR TITLE
fix: agp 9+ kotlin built-in support, rmv kotlin-android

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,6 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 plugins {
     id 'com.android.application'
     id 'com.google.devtools.ksp'
-    id 'kotlin-android'
     // rethink-tv fork: Compose Compiler plugin for the `tv` flavor's
     // Compose-for-TV UI. Safe to apply project-wide — phone variants
     // contain no @Composable and the plugin then no-ops.

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -1,15 +1,14 @@
 plugins {
     id 'com.android.test'
-    id 'org.jetbrains.kotlin.android'
 }
 
 android {
     namespace 'com.celzero.bravedns.benchmark'
-    compileSdk 36
+    compileSdk 37
 
     defaultConfig {
         minSdk 23
-        targetSdk 35
+        targetSdk 37
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark compatibility to Android SDK 37.
  * Streamlined Kotlin plugin configuration across app and benchmark modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->