### PR TITLE
Wire the dormant allowBypass pref into the VPN builder; add phone-UI toggle (fixes wireless Android Auto)

### DIFF
--- a/app/src/full/res/layout/activity_tunnel_settings.xml
+++ b/app/src/full/res/layout/activity_tunnel_settings.xml
@@ -184,6 +184,70 @@
                     android:layout_marginEnd="16dp" />
 
                 <RelativeLayout
+                    android:id="@+id/settings_activity_allow_bypass_rl"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:paddingTop="15dp"
+                    android:paddingBottom="15dp">
+
+                    <androidx.appcompat.widget.AppCompatImageView
+                        android:id="@+id/settings_activity_allow_bypass_icon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_centerVertical="true"
+                        android:layout_marginStart="5dp"
+                        android:layout_marginTop="5dp"
+                        android:layout_marginEnd="5dp"
+                        android:layout_marginBottom="5dp"
+                        android:alpha="0.5"
+                        android:padding="10dp"
+                        android:src="@drawable/ic_network_tunnel" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_centerVertical="true"
+                        android:layout_toStartOf="@id/settings_activity_allow_bypass_switch"
+                        android:layout_toEndOf="@id/settings_activity_allow_bypass_icon"
+                        android:orientation="vertical">
+
+                        <androidx.appcompat.widget.AppCompatTextView
+                            android:id="@+id/gen_settings_allow_bypass_txt"
+                            style="@style/TextAppearance.Material3.BodyLarge.Emphasized"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/settings_allow_bypass_heading" />
+
+                        <androidx.appcompat.widget.AppCompatTextView
+                            style="@style/TextAppearance.Material3.BodyMedium"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:paddingTop="3dp"
+                            android:text="@string/settings_allow_bypass_desc"
+                            android:textColor="?attr/colorOnSurfaceVariant" />
+                    </LinearLayout>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/settings_activity_allow_bypass_switch"
+                        style="@style/CustomWidget.Material3.CompoundButton.MaterialSwitch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentEnd="true"
+                        android:layout_centerVertical="true"
+                        android:padding="10dp" />
+
+                </RelativeLayout>
+
+                <com.google.android.material.divider.MaterialDivider
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="5dp"
+                    android:layout_marginBottom="5dp"
+                    android:layout_marginStart="56dp"
+                    android:layout_marginEnd="16dp" />
+
+                <RelativeLayout
                     android:id="@+id/settings_activity_all_network_rl"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
@@ -571,6 +571,13 @@ class BraveVPNService : VpnService(), ConnectionMonitor.NetworkListener, Network
         this.protect(fd.toInt())
     }
 
+    /**
+     * Builds the [Builder] for the VPN interface from the current persistent state:
+     * underlying networks, meteredness, app exclusions, and the allow-bypass flag
+     * (skipped in lockdown mode as the platform disallows bypass then). The caller
+     * ([establishVpn]) chains routes, DNS, and addresses onto this before
+     * [Builder.establish].
+     */
     private suspend fun newBuilder(): Builder {
         val builder = Builder()
         val underlyingNws = getUnderlays()
@@ -1462,6 +1469,12 @@ class BraveVPNService : VpnService(), ConnectionMonitor.NetworkListener, Network
         notifyConnectionStateChangeIfNeeded()
     }
 
+    /**
+     * Reacts to [PersistentState] changes: builder-affecting preferences (ex:
+     * [PersistentState.PRIVATE_IPS], [PersistentState.ALLOW_BYPASS]) request a
+     * debounced tunnel restart so the new builder takes effect; others update
+     * DNS, firewall, or notification state in place.
+     */
     override fun onSharedPreferenceChanged(preferences: SharedPreferences?, key: String?) {
         /* TODO Check on the Persistent State variable
         Check on updating the values for Package change and for mode change.

--- a/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/BraveVPNService.kt
@@ -592,6 +592,14 @@ class BraveVPNService : VpnService(), ConnectionMonitor.NetworkListener, Network
             logd("builder: set metered: ${persistentState.setVpnBuilderToMetered}")
         }
 
+        // let apps that explicitly request it (ex: Android Auto's wireless transport)
+        // bypass the tunnel; ignored in lockdown mode as the platform disallows bypass
+        // (VpnService.isLockdownEnabled)
+        if (!vpnLockdown && persistentState.allowBypass) {
+            builder.allowBypass()
+            logd("builder: allow bypass: true")
+        }
+
         // route rethink traffic in rethink based on the user selection
         if (!persistentState.routeRethinkInRethink) {
             Logger.i(LOG_TAG_VPN, "builder: exclude rethink app from builder")
@@ -1605,6 +1613,12 @@ class BraveVPNService : VpnService(), ConnectionMonitor.NetworkListener, Network
             PersistentState.PRIVATE_IPS -> {
                 // restart vpn to enable/disable route lan traffic
                 val reason = "routeLanTraffic: ${persistentState.privateIps}"
+                vpnRestartTrigger.value = reason
+            }
+
+            PersistentState.ALLOW_BYPASS -> {
+                // restart vpn to allow/disallow apps to bypass the tunnel
+                val reason = "allowBypass: ${persistentState.allowBypass}"
                 vpnRestartTrigger.value = reason
             }
 

--- a/app/src/main/java/com/celzero/bravedns/service/PersistentState.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/PersistentState.kt
@@ -82,6 +82,7 @@ class PersistentState(context: Context) : SimpleKrate(context), KoinComponent {
         const val TUN_NETWORK_POLICY = "tun_network_handling_policy"
         const val USE_MAX_MTU = "use_max_mtu"
         const val SET_VPN_BUILDER_TO_METERED = "set_vpn_builder_to_metered"
+        const val ALLOW_BYPASS = "allow_bypass"
 
         // SE Proxy for Anti-Censorship
         const val AUTO_PROXY_ENABLED = "auto_proxy_enabled"

--- a/app/src/main/java/com/celzero/bravedns/ui/activity/TunnelSettingsActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/activity/TunnelSettingsActivity.kt
@@ -106,6 +106,7 @@ class TunnelSettingsActivity : BaseActivity(R.layout.activity_tunnel_settings) {
         private const val FOUR_MB_IN_BYTES = 4 * 1024 * 1024
     }
 
+    /** Applies the persisted theme and inflates the tunnel-settings screen. */
     override fun onCreate(savedInstanceState: Bundle?) {
         theme.applyStyle(Themes.getCurrentTheme(isDarkThemeOn(), persistentState.theme), true)
         //setTheme(Themes.getCurrentTheme(isDarkThemeOn(), persistentState.theme))
@@ -123,6 +124,7 @@ class TunnelSettingsActivity : BaseActivity(R.layout.activity_tunnel_settings) {
         setupClickListeners()
     }
 
+    /** Returns true when the system is in dark mode. */
     private fun Context.isDarkThemeOn(): Boolean {
         return resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
             Configuration.UI_MODE_NIGHT_YES
@@ -213,12 +215,12 @@ class TunnelSettingsActivity : BaseActivity(R.layout.activity_tunnel_settings) {
     }
 
 
-    private fun displayDialerTimeOutUi(progressSec: Int) {
+    /** Renders the anti-censorship dialer timeout as a human-readable label. */progressSec: Int) {
         val displayText = formatTimeShort(progressSec)
         b.dvTimeoutValue.text = displayText
     }
 
-    private fun formatTimeShort(totalSeconds: Int): String {
+    /** Formats seconds as a compact h/m/s string (empty parts skipped). */totalSeconds: Int): String {
         val hours = totalSeconds / SECONDS_PER_HOUR
         val minutes = (totalSeconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
         val seconds = totalSeconds % SECONDS_PER_MINUTE
@@ -232,18 +234,18 @@ class TunnelSettingsActivity : BaseActivity(R.layout.activity_tunnel_settings) {
         return if (parts.isEmpty()) getString(R.string.lbl_disabled) else parts.joinToString(" ")
     }
 
-    private fun updateDialerTimeOut(valueMin: Int) {
+    /** Persists the dialer timeout (minutes) and refreshes its label. */valueMin: Int) {
         val inSec = valueMin * SECONDS_PER_MINUTE
         persistentState.dialTimeoutSec = inSec
         displayDialerTimeOutUi(inSec)
     }
 
-    private fun displaySocketBufferSizeUi(bytes: Int) {
+    /** Renders the socket buffer size as a human-readable label. */bytes: Int) {
         val displayText = formatSocketBufferSize(bytes)
         b.dvSocketBufferSizeValue.text = displayText
     }
 
-    private fun formatSocketBufferSize(bytes: Int): String {
+    /** Formats a byte count as KB/MB for display. */bytes: Int): String {
         val kb = bytes / 1024
         return if (kb >= 1024) {
             "${kb / 1024} MB"

--- a/app/src/main/java/com/celzero/bravedns/ui/activity/TunnelSettingsActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/activity/TunnelSettingsActivity.kt
@@ -128,6 +128,7 @@ class TunnelSettingsActivity : BaseActivity(R.layout.activity_tunnel_settings) {
             Configuration.UI_MODE_NIGHT_YES
     }
 
+    /** Re-evaluates lockdown-dependent row states when the screen returns to the foreground. */
     override fun onResume() {
         super.onResume()
         handleLockdownModeIfNeeded()
@@ -265,6 +266,7 @@ class TunnelSettingsActivity : BaseActivity(R.layout.activity_tunnel_settings) {
         displaySocketBufferSizeUi(bytes)
     }
 
+    /** Shows the socket-buffer-size chooser, an advanced TCP/UDP tuning preference. */
     private fun suggestSocketBufferSize() {
         if (persistentState.socketBufferSizeBytes < FOUR_MB_IN_BYTES) {
             val progress = socketBufferSizeToProgress(FOUR_MB_IN_BYTES)

--- a/app/src/main/java/com/celzero/bravedns/ui/activity/TunnelSettingsActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/activity/TunnelSettingsActivity.kt
@@ -215,12 +215,14 @@ class TunnelSettingsActivity : BaseActivity(R.layout.activity_tunnel_settings) {
     }
 
 
-    /** Renders the anti-censorship dialer timeout as a human-readable label. */progressSec: Int) {
+    /** Renders the anti-censorship dialer timeout as a human-readable label. */
+    private fun displayDialerTimeOutUi(progressSec: Int) {
         val displayText = formatTimeShort(progressSec)
         b.dvTimeoutValue.text = displayText
     }
 
-    /** Formats seconds as a compact h/m/s string (empty parts skipped). */totalSeconds: Int): String {
+    /** Formats seconds as a compact h/m/s string (empty parts skipped). */
+    private fun formatTimeShort(totalSeconds: Int): String {
         val hours = totalSeconds / SECONDS_PER_HOUR
         val minutes = (totalSeconds % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE
         val seconds = totalSeconds % SECONDS_PER_MINUTE
@@ -234,18 +236,21 @@ class TunnelSettingsActivity : BaseActivity(R.layout.activity_tunnel_settings) {
         return if (parts.isEmpty()) getString(R.string.lbl_disabled) else parts.joinToString(" ")
     }
 
-    /** Persists the dialer timeout (minutes) and refreshes its label. */valueMin: Int) {
+    /** Persists the dialer timeout (minutes) and refreshes its label. */
+    private fun updateDialerTimeOut(valueMin: Int) {
         val inSec = valueMin * SECONDS_PER_MINUTE
         persistentState.dialTimeoutSec = inSec
         displayDialerTimeOutUi(inSec)
     }
 
-    /** Renders the socket buffer size as a human-readable label. */bytes: Int) {
+    /** Renders the socket buffer size as a human-readable label. */
+    private fun displaySocketBufferSizeUi(bytes: Int) {
         val displayText = formatSocketBufferSize(bytes)
         b.dvSocketBufferSizeValue.text = displayText
     }
 
-    /** Formats a byte count as KB/MB for display. */bytes: Int): String {
+    /** Formats a byte count as KB/MB for display. */
+    private fun formatSocketBufferSize(bytes: Int): String {
         val kb = bytes / 1024
         return if (kb >= 1024) {
             "${kb / 1024} MB"

--- a/app/src/main/java/com/celzero/bravedns/ui/activity/TunnelSettingsActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/activity/TunnelSettingsActivity.kt
@@ -143,6 +143,8 @@ class TunnelSettingsActivity : BaseActivity(R.layout.activity_tunnel_settings) {
         b.settingsActivityAllNetworkSwitch.isChecked = persistentState.useMultipleNetworks
         // route lan traffic
         b.settingsActivityLanTrafficSwitch.isChecked = persistentState.privateIps
+        // allow apps to bypass the tunnel
+        b.settingsActivityAllowBypassSwitch.isChecked = persistentState.allowBypass
         // show ping ips
         b.settingsActivityPingIpsBtn.visibility = if (persistentState.connectivityChecks) View.VISIBLE else View.GONE
         // exclude apps in proxy
@@ -372,6 +374,21 @@ class TunnelSettingsActivity : BaseActivity(R.layout.activity_tunnel_settings) {
             logEvent(
                 "route lan traffic",
                 "Route LAN traffic: $checked"
+            )
+        }
+
+        b.settingsActivityAllowBypassRl.setOnClickListener {
+            b.settingsActivityAllowBypassSwitch.isChecked =
+                !b.settingsActivityAllowBypassSwitch.isChecked
+        }
+
+        b.settingsActivityAllowBypassSwitch.setOnCheckedChangeListener {
+            _: CompoundButton,
+            checked: Boolean ->
+            persistentState.allowBypass = checked
+            logEvent(
+                "allow bypass",
+                "Allow apps to bypass the tunnel: $checked"
             )
         }
 

--- a/app/src/main/java/com/celzero/bravedns/ui/activity/TunnelSettingsActivity.kt
+++ b/app/src/main/java/com/celzero/bravedns/ui/activity/TunnelSettingsActivity.kt
@@ -133,6 +133,7 @@ class TunnelSettingsActivity : BaseActivity(R.layout.activity_tunnel_settings) {
         handleLockdownModeIfNeeded()
     }
 
+    /** Hydrates all tunnel-setting rows (switches, labels, visibility) from [persistentState]. */
     private fun initView() {
         b.settingsActivityWireguardText.text = getString(R.string.settings_proxy_header)
         val text = getString(R.string.two_argument, getString(R.string.orbot_status_arg_2), getString(R.string.lbl_ip))
@@ -272,6 +273,7 @@ class TunnelSettingsActivity : BaseActivity(R.layout.activity_tunnel_settings) {
         }
     }
 
+    /** Wires row clicks and switch listeners; most write straight to [persistentState], which the VPN service observes. */
     private fun setupClickListeners() {
         b.settingsActivityAllNetworkRl.setOnClickListener {
             b.settingsActivityAllNetworkSwitch.isChecked =


### PR DESCRIPTION
## What

Wires the dormant `allowBypass` persistent preference into the VPN builder and adds the corresponding phone-UI toggle (the TV build already ships a toggle for this pref; the strings `settings_allow_bypass_heading`/`_desc` have been in `values/strings.xml` all along — only the wire-up was missing).

Fixes #2685.

## Root cause

`PersistentState.allowBypass` exists (`allow_bypass`, default `false`) and `SettingsScreen.kt` (TV) writes it, but `BraveVPNService` never reads it — `VpnService.Builder.allowBypass()` is never called, so the established VPN is always non-bypassable:

```
$ dumpsys connectivity | grep -A2 'VPN CONNECTED'
  ni{VPN CONNECTED extra: VPN:com.celzero.bravedns} ...
  TransportInfo: <VpnTransportInfo{type=1, sessionId=Rethink, bypassable=false ...}>
```

Wireless Android Auto negotiates its transport over Wi-Fi-Direct and checks the *default network object*: when it is a non-bypassable VPN, the session is refused regardless of per-app configuration:

```
NearbyMediums: [WifiNetworkV2] defaultNetworkCallback onCapabilitiesChanged network:NNN [ CELLULAR VPN ] isNonBypassable:true
GH.WirelessStartup: ProjectionErrorCode = 3, ProjectionErrorDetail = 52, io error
GH.WIRELESS.SETUP: State changed to START_WIFI_REQUEST_FAILED_WIFI_NOT_YET_STARTED
```

App-level workarounds (Exclude / Bypass DNS & Firewall for `com.google.android.projection.gearhead`) do not help because the check inspects the network, not tunnel membership. With `builder.allowBypass()` called at establish, the platform surfaces `bypassable=true` and apps that explicitly opt out (`bindProcessToNetwork`, as AA's transport does) can use the underlying network — the documented purpose of [`VpnService.Builder.allowBypass()`](https://developer.android.com/reference/android/net/VpnService.Builder#allowBypass()).

## Changes

- `BraveVPNService.newBuilder()`: call `builder.allowBypass()` when the pref is enabled, skipped under VPN lockdown (the platform disallows bypass in lockdown mode — mirrors the existing excluded-apps guard).
- `BraveVPNService.onSharedPreferenceChanged()`: restart the tunnel when the pref changes (same one-liner as the `PRIVATE_IPS` branch — `allowBypass()` is additive, so disabling requires a rebuild of the builder).
- `TunnelSettingsActivity` + `activity_tunnel_settings.xml`: new "Enable network visibility" toggle row cloned from the lan-traffic row, using the existing strings.

No behavior change by default (`allowBypass` defaults to `false`; opt-in via the new toggle).

Note: with this change the TV build's toggle becomes functional too (it currently writes a pref nothing reads). A follow-up could switch its hardcoded labels to `settings_allow_bypass_heading`.

## Testing

Built `assembleFdroidFullReleaseDebug`, installed on a Pixel 8 Pro (Android 17), Rethink active:
- Toggle appears in Configure → Network; enabling it restarts the tunnel (via the `ALLOW_BYPASS` pref branch).
- `dumpsys connectivity` shows the VPN `bypassable=true` after the restart.
- DNS blocking unaffected (`doubleclick.net` → `127.0.0.1`).
- Wireless Android Auto session negotiates with the VPN active (the reported failure mode in #2685).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tunnel setting that lets apps bypass the VPN tunnel.
  * Added a switch, icon, and descriptive text for enabling or disabling app bypass.
  * The selected preference is saved and reflected in tunnel settings.
  * Changes take effect automatically when the setting is updated.

* **Bug Fixes**
  * Ensured VPN configuration reflects the selected bypass preference when lockdown mode is inactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->