### PR TITLE
fix(vpn): re-enable dial idle timeout by default to prevent permanent connection stalls

### DIFF
--- a/app/src/main/java/com/celzero/bravedns/service/PersistentState.kt
+++ b/app/src/main/java/com/celzero/bravedns/service/PersistentState.kt
@@ -422,7 +422,26 @@ class PersistentState(context: Context) : SimpleKrate(context), KoinComponent {
 
     var nwEngExperimentalFeatures by booleanPref("network_engine_experimental").withDefault<Boolean>(false)
 
-    var dialTimeoutSec by intPref("dial_timeout_sec").withDefault<Int>(0)
+    // Default dial idle timeout, in seconds, for outgoing TCP/UDP connections.
+    //
+    // IMPORTANT: a value of 0 is not merely "no timeout" -- it changes code path.
+    // See intra/rwconn.go (rwext.SetTimeout()) and intra/common.go (forward()):
+    // when this is 0, SetTimeoutSockOpt() is never invoked, rwext.SetTimeout()
+    // returns didSet=false, and forward() unwraps the connection down past the
+    // *dialers.retrier entirely (a "zero-copy" optimization). That retrier is
+    // what performs automatic retry-on-stall/retry-on-error (up to
+    // maxRetryCount) for otherwise-silent connection stalls (no RST, no EOF,
+    // just zero bytes forever). With the default at 0, a silently-stalled TCP
+    // connection has no recovery path and hangs indefinitely.
+    //
+    // We observed this cause real, reproducible, permanent playback freezes on
+    // low-power Android TV/Fire TV Stick hardware: a video CDN connection would
+    // complete its TCP handshake via the VPN's Exit path and then simply never
+    // transfer another byte, with no error surfaced to the app or the VPN
+    // service. Changing this default to a small positive value (10s) restores
+    // the retrier safety net for everyone, at the cost of a small amount of
+    // deadline-tracking overhead per read/write on every connection.
+    var dialTimeoutSec by intPref("dial_timeout_sec").withDefault<Int>(10)
 
     // treat only mobile data as metered
     var treatOnlyMobileNetworkAsMetered by booleanPref("treat_only_mobile_nw_as_metered").withDefault<Boolean>(false)
@@ -889,7 +908,7 @@ class PersistentState(context: Context) : SimpleKrate(context), KoinComponent {
         endpointIndependence = false
         nwEngExperimentalFeatures = false
         tcpKeepAlive = false
-        dialTimeoutSec = 0
+        dialTimeoutSec = 10
         socketBufferSizeBytes = DEFAULT_SOCKET_BUFFER_SIZE_BYTES
         useMaxMtu = false
         setVpnBuilderToMetered = false


### PR DESCRIPTION
## Summary

`PersistentState.dialTimeoutSec` defaults to `0`. On real (non-emulator) low-power Android TV / Fire TV Stick hardware, this default causes **permanent, unrecoverable connection freezes** for some apps' video/streaming traffic, because a timeout of `0` is not merely "no timeout" -- it silently changes the code path used for every proxied connection in Firestack.

This PR changes the default to `10` seconds, which restores the retrier's built-in stall-detection/auto-retry behavior for all users, at the cost of a small per-connection deadline-tracking overhead.

## Root cause (traced in Firestack source)

In `intra/rwconn.go`:

```go
func (rw rwext) SetTimeout() (secs int, didSet bool) {
    r, w := rw.deadlines()
    secs = max(int(r), int(w))
    if r > 0 {
        // always returns false for udp conns
        didSet = core.SetTimeoutSockOpt(rw.Unwrap(), secs*1000)
    }
    ...
}
```

`SetTimeoutSockOpt()` (which applies `SO_RCVTIMEO`/`SO_SNDTIMEO` directly on the underlying socket fd) is only even attempted when the deadline is `> 0`. With `dialTimeoutSec = 0`, this never happens, and `didSet` stays `false`.

In `intra/common.go`, `forward()` checks `didSet` and, when `false`, **unwraps the connection past the `*dialers.retrier` wrapper entirely** as a "zero-copy" optimization -- the assumption being that if the OS itself isn't enforcing a deadline, there's nothing for the retrier to protect against. This means `dialers.retrier`'s automatic retry-on-stall / retry-on-error logic (up to `maxRetryCount` attempts, see `intra/dialers/retrier.go`) is **completely bypassed** for the lifetime of any connection opened while `dialTimeoutSec == 0`.

The result: a connection that stalls silently -- TCP handshake completes, then zero further bytes transfer, no RST, no EOF, no error surfaced anywhere in the stack -- has **no mechanism left to detect or recover from the stall**. It hangs forever.

## How we found this

We were debugging a reproducible playback freeze in a specific streaming app on a real Fire TV Stick (Fire OS, ~900MB RAM, armeabi-v7a). Isolation testing showed:
- VPN off: playback worked every time.
- VPN on, app allowed through the tunnel normally: playback froze, indefinitely, on a small percentage of app launches.
- VPN on, app excluded from the VPN tunnel: playback worked every time.

This ruled out the app/CDN itself and pointed at the VPN/tunneling layer. Packet-level and Firestack-log-level tracing (via `adb logcat`, matching the offending connection's CID across `RethinkDnsVpn`/`Firestack` log lines) showed the connection completing its TCP handshake via the Exit proxy path and then transferring exactly zero further bytes for the remainder of the session -- while other apps' connections through the same tunnel, at the same time, continued to work normally. This ruled out a general tunnel/network failure and pointed specifically at this one connection having no recovery path.

Reading the Firestack source (pinned commit referenced in our fork) led to the `rwext.SetTimeout()` / `forward()` code path described above, and confirmed `dialTimeoutSec`'s default of `0` was the reason no retry ever kicked in.

## Fix and verification

Changed the default from `0` to `10` (both the property declaration and `restoreTunnelSettingsDefaults()`).

Rebuilt, redeployed to the same physical Fire TV Stick, and reproduced the exact same scenario. Logcat confirmed:
- `optset? true (10s)` now appears on the dial log line (previously this connection would have shown `optset? false`, i.e., retrier unwrapped).
- The previously-permanently-stuck connection now surfaces `EOF` and the retrier automatically retries **3 times** (~3s apart, matching `maxRetryCount`), recovering successfully within roughly 9-10 seconds, matching the configured 10s deadline.
- User-facing result: what used to be a permanent freeze became, at worst, a ~10 second delay before playback resumed on its own.

## Trade-offs / why `10`, not something else

- `0` (current default) disables the safety net entirely; any value `> 0` restores it.
- We chose `10` as a reasonable balance: long enough to avoid nuisance retries on connections that are just naturally slow (mobile networks, distant CDNs), short enough that a genuinely stalled connection recovers within a time a user will tolerate rather than assume the app is broken.
- This is a small increase in per-read/write overhead (deadline tracking via the retrier wrapper) compared to the previous zero-copy fast path. In our testing this was not measurable against the benefit of eliminating indefinite hangs.
- The setting is already fully user-configurable (Settings > VPN > dial timeout), so anyone who specifically wants the old zero-copy/no-timeout behavior can still opt back into `0` manually -- this PR only changes what new installs / users who haven't touched this setting get by default.

## Scope of this PR

This is intentionally a minimal, isolated, one-setting change:
- `app/src/main/java/com/celzero/bravedns/service/PersistentState.kt`:
  - `dialTimeoutSec` property default: `0` -> `10` (with an explanatory comment referencing the exact Firestack code path).
  - `restoreTunnelSettingsDefaults()`: matching default updated to `10`.

No other files touched, no bundled/unrelated changes.

## Testing performed

- Reproduced the freeze repeatedly on a real Fire TV Stick (not an emulator) with the setting at its old default of `0`.
- Applied this exact change, rebuilt from source, redeployed to the same device.
- Captured fresh `adb logcat` output before and after and confirmed the retrier is now engaged (`optset? true (10s)`) and automatically recovers stalled connections instead of hanging indefinitely.
- Confirmed via repeated reproduction attempts that connections which previously hung forever now resolve within the configured timeout window.

Happy to share sanitized logcat excerpts if useful for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved connection reliability by setting the default dial timeout to 10 seconds.
  - Restoring default tunnel settings now applies the 10-second dial timeout, helping prevent stalled connections from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->